### PR TITLE
docs: minor typo in sample code and error message

### DIFF
--- a/addons/gdUnit4/src/GdUnitTestSuite.gd
+++ b/addons/gdUnit4/src/GdUnitTestSuite.gd
@@ -153,8 +153,8 @@ func await_millis(timeout :int):
 ## The runner will manage the scene instance and release after the runner is released[br]
 ## example:[br]
 ## [codeblock]
-##    # creates a runner by using a instanciated scene
-##    var scene = load("res://foo/my_scne.tscn").instantiate() 
+##    # creates a runner by using a instantiated scene
+##    var scene = load("res://foo/my_scne.tscn").instantiate()
 ##    var runner := scene_runner(scene)
 ##
 ##    # or simply creates a runner by using the scene resource path

--- a/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
+++ b/addons/gdUnit4/src/mocking/GdUnitMockBuilder.gd
@@ -64,7 +64,7 @@ static func mock_on_scene(scene :PackedScene, memory_pool :int, debug_write :boo
 	var push_errors := is_push_errors()
 	if not scene.can_instantiate():
 		if push_errors:
-			push_error("Can't instanciate scene '%s'" % scene.resource_path)
+			push_error("Can't instantiate scene '%s'" % scene.resource_path)
 		return null
 	var scene_instance = scene.instantiate()
 	# we can only mock checked a scene with attached script

--- a/docs/api/saveload.md
+++ b/docs/api/saveload.md
@@ -7,7 +7,7 @@ Pandora allows you to load and save changed data effortlessly. The data defined 
 var sword:PandoraEntityInstance
 
 func _ready() -> void:
-   self.sword = Pandora.get_entity(EntityIds.SWORD).instanciate()
+   self.sword = Pandora.get_entity(EntityIds.SWORD).instantiate()
 ```
 
 With PandoraEntityInstance in hand, you might think of writing game data to a JSON file. For a comprehensive overview of setting up a savegame system in Godot, [check out this guide](https://docs.godotengine.org/en/stable/tutorials/io/saving_games.html). Here is [a practical `SaveGame` mechanism example](https://github.com/bitbrain/godot-gamejam/blob/main/godot/savegame/SaveGame.gd) to help you visualize it better.


### PR DESCRIPTION
Fixes cases of `instanciate` -> `instantiate`.

-------

## Description

Saw a minor typo in a method in the docs, and was curious if it was an
intentional deviation or just a typo - upon digging, seems it's just a quick
fix. Did a global search and found two other instances, in an error message and
a comment.

-------

Thanks so much for Pandora! It's a powerful tool and I'm enjoying digging into it!