### PR TITLE
Added string representation for model resources.

### DIFF
--- a/addons/pandora/model/category.gd
+++ b/addons/pandora/model/category.gd
@@ -23,3 +23,6 @@ func _delete_property(name:String) -> void:
 	super._delete_property(name)
 	for child in _children:
 		child._delete_property(name)
+
+func _to_string() -> String:
+	return "<PandoraCategory " + str(_children) + ">"

--- a/addons/pandora/model/entity.gd
+++ b/addons/pandora/model/entity.gd
@@ -420,3 +420,7 @@ func _create_instance_properties() -> Array[PandoraPropertyInstance]:
 		var default_value = property.get_default_value()
 		property_instances.append(PandoraPropertyInstance.new(property, default_value))
 	return property_instances
+
+
+func _to_string() -> String:
+	return "<PandoraEntity '" + _name + "'>"

--- a/addons/pandora/model/entity_instance.gd
+++ b/addons/pandora/model/entity_instance.gd
@@ -189,3 +189,7 @@ func _load_properties(data:Array) -> Dictionary:
 	
 func _get_property_value(name:String) -> Variant:
 	return _properties[name].get_property_value()
+	
+	
+func _to_string() -> String:
+	return "<PandoraEntityInstance '" + get_entity_name() + "'>"

--- a/addons/pandora/model/entity_proxy.gd
+++ b/addons/pandora/model/entity_proxy.gd
@@ -71,3 +71,7 @@ func save_data() -> Dictionary:
 
 func _get_entity() -> PandoraEntity:
 	return Pandora.get_entity(proxied_entity_id)
+
+
+func _to_string() -> String:
+	return "<PandoraEntityProxy '" + _name + "'>"

--- a/addons/pandora/model/property.gd
+++ b/addons/pandora/model/property.gd
@@ -198,3 +198,7 @@ func _type_checks() -> Dictionary:
 		"reference": func(variant): return variant is PandoraEntity,
 		"resource": func(variant): return variant is Resource
 	}
+
+
+func _to_string() -> String:
+	return "<PandoraProperty '" + get_property_name() + "' (" + get_property_type() + ")>"

--- a/addons/pandora/model/property_instance.gd
+++ b/addons/pandora/model/property_instance.gd
@@ -42,3 +42,6 @@ func save_data() -> Dictionary:
 		"_value": _value,
 		"_property_id": _property_id
 	}
+
+func _to_string() -> String:
+	return "<PandoraPropertyInstance '" + get_property_name() + "'>"

--- a/addons/pandora/model/reference.gd
+++ b/addons/pandora/model/reference.gd
@@ -36,3 +36,6 @@ func save_data() -> Dictionary:
 		"_entity_id": _entity_id,
 		"_type":_type
 	}
+
+func _to_string() -> String:
+	return "<PandoraReference" + str(get_entity()) + ">"


### PR DESCRIPTION
Custom resources are printable for easier debugging.

## Addressed issues

Closes #77 

String formats are very much up to discussion - to capture the most important info in each entity.

## Screenshots

```gdscript
# Changes this:
Pandora error: value <Resource#-9223368908105259524> is incompatible with type reference
# into this:
Pandora error: value <PandoraReference<PandoraEntity 'Epic'>> is incompatible with type reference
```
