### PR TITLE
Bugfix: Setting a reference property

### DIFF
--- a/addons/pandora/ui/components/properties/reference/reference_property.gd
+++ b/addons/pandora/ui/components/properties/reference/reference_property.gd
@@ -21,8 +21,7 @@ func _ready() -> void:
 	entity_picker.focus_entered.connect(func(): focused.emit())
 	entity_picker.entity_selected.connect(
 		func(entity:PandoraEntity):
-			var reference = PandoraReference.new(entity.get_entity_id(), 1 if entity is PandoraCategory else 0)
-			_property.set_default_value(reference)
+			_property.set_default_value(entity)
 			property_value_changed.emit())
 
 


### PR DESCRIPTION
## Description

The newly set entity was wrapped in `PandoraReference` too early - it needs to be passed into `set_default_value` as an entity and only after that it's set into property overrides wrapped in `PandoraReference`.

## Addressed issues

Closes #79 
