### PR TITLE
:bug: do not use custom constructor for resource

### DIFF
--- a/addons/pandora/backend/entity_backend.gd
+++ b/addons/pandora/backend/entity_backend.gd
@@ -39,7 +39,8 @@ func create_entity(name:String, category:PandoraCategory) -> PandoraEntity:
 
 ## Creates a new category on an optional parent category
 func create_category(name:String, parent_category:PandoraCategory = null) -> PandoraCategory:
-	var category = PandoraCategory.new(_id_generator.generate(), name, "", "")
+	var category = PandoraCategory.new()
+	category.init_entity(_id_generator.generate(), name, "", "")
 	if parent_category != null:
 		parent_category._children.append(category)
 		category._category_id = parent_category._id
@@ -226,7 +227,7 @@ func _deserialize_entities(data:Array) -> Dictionary:
 func _deserialize_categories(data:Array) -> Dictionary:
 	var dict = {}
 	for category_data in data:
-		var category = PandoraCategory.new("", "", "", "")
+		var category = PandoraCategory.new()
 		category.load_data(category_data)
 		dict[category._id] = category
 		if category._category_id == "":
@@ -298,18 +299,25 @@ func _get_entity_class(path:String) -> GDScript:
 
 func _create_entity_from_script(path:String, id:String, name:String, icon_path:String, category_id:String):
 	var clazz = _get_entity_class(path)
-	var new_method = _find_first_method_of_script(clazz, "_init")
+	var new_method = _find_first_method_of_script(clazz, "init_entity")
 	if not new_method.has("args"):
 		push_error("ERROR - Pandora is unable to correctly resolve new() method.")
-		return PandoraEntityScript.new(id, name, icon_path, category_id)
-	var expected_method = _find_first_method_of_script(PandoraEntityScript, "_init")
+		var entity = PandoraEntityScript.new()
+		entity.init_entity(id, name, icon_path, category_id)
+		return entity
+	var expected_method = _find_first_method_of_script(PandoraEntityScript, "init_entity")
 	if new_method["args"].size() != expected_method["args"].size():
-		push_warning("_init() method has incorrect signature! Requires " + str(expected_method["args"].size()) + " arguments - defaulting to PandoraEntity instead.")
-		return PandoraEntityScript.new(id, name, icon_path, category_id)
-	var entity = clazz.new(id, name, icon_path, category_id)
+		push_warning("init_entity() method has incorrect signature! Requires " + str(expected_method["args"].size()) + " arguments - defaulting to PandoraEntity instead.")
+		var entity = PandoraEntityScript.new()
+		entity.init_entity(id, name, icon_path, category_id)
+		return entity
+		
+	var entity = clazz.new()
 	if not entity is PandoraEntity:
 		push_warning("Script '" + path + "' must extend PandoraEntity - defaulting to PandoraEntity instead.")
-		entity = PandoraEntityScript.new(id, name, icon_path, category_id)
+		entity = PandoraEntityScript.new()
+	
+	entity.init_entity(id, name, icon_path, category_id)
 	return entity
 
 

--- a/addons/pandora/model/entity.gd
+++ b/addons/pandora/model/entity.gd
@@ -138,7 +138,9 @@ var _generate_ids = false
 var _ids_generation_class = ""
 
 
-func _init(id:String, name:String, icon_path:String, category_id:String) -> void:
+## do not rely on _init as it breaks .tres files that may still
+## point to a migrated PandoraEntity custom script.
+func init_entity(id:String, name:String, icon_path:String, category_id:String) -> void:
 	self._id = id
 	self._name = name
 	self._icon_path = icon_path

--- a/addons/pandora/model/entity_proxy.gd
+++ b/addons/pandora/model/entity_proxy.gd
@@ -11,10 +11,6 @@ class_name PandoraEntityProxy extends PandoraEntity
 
 
 @export var proxied_entity_id:String
-
-
-func _init() -> void:
-	super._init("", "", "", "")
 	
 	
 func instantiate() -> PandoraEntityInstance:


### PR DESCRIPTION
Closes #85

## Description

Migrating existing projects to Pandora can be cumbersome when using .tres files and trying to change the `extends Resource` to `extends PandoraEntity` for custom scripts. Suddenly, Godot cannot initialise the pre-existing `.tres` files and it breaks everything.

This PR ensures that `PandoraEntity` can still be initialised by Godot if it is based on a `.tres` file during migration.