### PR TITLE
:recycle: rework property type lookup

### DIFF
--- a/addons/pandora/backend/entity_backend.gd
+++ b/addons/pandora/backend/entity_backend.gd
@@ -54,11 +54,12 @@ func create_category(name:String, parent_category:PandoraCategory = null) -> Pan
 
 
 ## Creates a new property on the given category parent
-func create_property(on_category:PandoraCategory, name:String, type:String, defaultValue:Variant = null) -> PandoraProperty:
+func create_property(on_category:PandoraCategory, name:String, type:String, default_value:Variant = null) -> PandoraProperty:
 	if on_category.has_entity_property(name):
 		push_error("Unable to create property " + name + " - property with the same name exists.")
 		return null
-	var property = PandoraProperty.new(_id_generator.generate(), name, type, defaultValue if defaultValue else PandoraProperty.default_value_of(type))
+	var property = PandoraProperty.new(_id_generator.generate(), name, type)
+	property.set_default_value(default_value)
 	property._category_id = on_category._id
 	_properties[property._id] = property
 	on_category._properties.append(property)
@@ -239,7 +240,7 @@ func _deserialize_categories(data:Array) -> Dictionary:
 func _deserialize_properties(data:Array) -> Dictionary:
 	var dict = {}
 	for property_data in data:
-		var property = PandoraProperty.new("", "", "", "")
+		var property = PandoraProperty.new("", "", "")
 		property.load_data(property_data)
 		dict[property._id] = property
 	return dict

--- a/addons/pandora/model/category.gd
+++ b/addons/pandora/model/category.gd
@@ -24,5 +24,6 @@ func _delete_property(name:String) -> void:
 	for child in _children:
 		child._delete_property(name)
 
+
 func _to_string() -> String:
 	return "<PandoraCategory " + str(_children) + ">"

--- a/addons/pandora/model/entity.gd
+++ b/addons/pandora/model/entity.gd
@@ -58,9 +58,13 @@ class OverridingProperty extends PandoraProperty:
 	
 	func get_setting_override(name:String) -> Variant:
 		return _property.get_setting_override(name)
+		
+		
+	func get_setting(name:String) -> Variant:
+		return _property.get_setting(name)
 	
 	
-	func has_setting_override(name:String) -> Variant:
+	func has_setting_override(name:String) -> bool:
 		return _property.has_setting_override(name)
 		
 		
@@ -73,7 +77,7 @@ class OverridingProperty extends PandoraProperty:
 
 
 	func set_default_value(value: Variant) -> void:
-		if not is_valid_type(value):
+		if not get_property_type().is_valid(value):
 			print("Pandora error: value " + str(value) + " is incompatible with type ", get_property_type())
 			return
 		# ensure that a supported type is assigned.
@@ -99,7 +103,7 @@ class OverridingProperty extends PandoraProperty:
 		return _property.get_property_name()
 
 
-	func get_property_type() -> String:
+	func get_property_type() -> PandoraPropertyType:
 		return _property.get_property_type()
 		
 	
@@ -436,9 +440,10 @@ func _save_overrides() -> Dictionary:
 	for property_name in _property_overrides:
 		var value = _property_overrides[property_name]
 		var property = get_entity_property(property_name)
+		var type = property.get_property_type()
 		output[property_name] = {
-			"type": property.get_property_type(),
-			"value": PandoraProperty.write_value(value)
+			"type": type.get_type_name(),
+			"value": type.write_value(value)
 			}
 	return output
 	
@@ -447,7 +452,8 @@ func _load_overrides(data:Dictionary) -> Dictionary:
 	var output = {}
 	for property_name in data:
 		var unparsed_data = data[property_name]
-		output[property_name] = PandoraProperty.parse_value(unparsed_data["value"], unparsed_data["type"])
+		var type = PandoraPropertyType.lookup(unparsed_data["type"])
+		output[property_name] = type.parse_value(unparsed_data["value"])
 	return output
 
 

--- a/addons/pandora/model/property.gd
+++ b/addons/pandora/model/property.gd
@@ -3,7 +3,7 @@
 ## different entities (depending on the way they get inherited).
 ## This ensures that changing the original property will automatically
 ## apply to any other entity that is using it.
-class_name PandoraProperty extends Resource
+class_name PandoraProperty extends RefCounted
 
 
 ## Emitted when the name of this property changed.
@@ -19,30 +19,30 @@ var _name: String:
 		_name = n
 		if _name != old:
 			name_changed.emit(old, _name)
-var _type: String
+var _type: PandoraPropertyType
 var _default_value: Variant
 var _category_id:String
 # setting name -> Variant
 var _setting_overrides:Dictionary = {}
 
 
-func _init(id:String, name:String, type:String, default_value:Variant) -> void:
+func _init(id:String, name:String, type_name:String) -> void:
 	self._id = id
 	self._name = name
-	self._type = type
-	if self._type != "" and not is_valid_type(default_value):
-		print("Pandora error: value " + str(default_value) + " is incompatible with type ", type)
+	self._type = PandoraPropertyType.lookup(type_name)
+	self._default_value = _type.get_default_value()
+	
+	
+func get_setting(key:String) -> Variant:
+	if has_setting_override(key):
+		return _setting_overrides[key]
+	elif _type != null:
+		return _type.get_settings()[key]["value"]
 	else:
-		self._default_value = default_value
-	
-	
-func get_setting_override(name:String) -> Variant:
-	if _setting_overrides.has(name):
-		return _setting_overrides[name]
-	return null
-	
-	
-func has_setting_override(name:String) -> Variant:
+		return null
+		
+		
+func has_setting_override(name:String) -> bool:
 	return _setting_overrides.has(name)
 	
 	
@@ -57,7 +57,7 @@ func clear_setting_override(name:String) -> void:
 
 
 func set_default_value(value:Variant) -> void:
-	if not is_valid_type(value):
+	if not _type.is_valid(value):
 		print("Pandora error: value " + str(value) + " is incompatible with type ", _type)
 		return
 	# ensure that a supported type is assigned.
@@ -74,7 +74,7 @@ func get_property_name() -> String:
 	return _name
 
 
-func get_property_type() -> String:
+func get_property_type() -> PandoraPropertyType:
 	return _type
 
 
@@ -115,8 +115,8 @@ func is_overridden() -> bool:
 func load_data(data:Dictionary) -> void:
 	_id = data["_id"]
 	_name = data["_name"]
-	_type = data["_type"]
-	_default_value = parse_value(data["_default_value"], _type)
+	_type = PandoraPropertyType.lookup(data["_type"])
+	_default_value = _type.parse_value(data["_default_value"])
 	_category_id = data["_category_id"]
 	if data.has("_setting_overrides"):
 		_setting_overrides = data["_setting_overrides"]
@@ -126,79 +126,14 @@ func save_data() -> Dictionary:
 	var data = {
 		"_id": _id,
 		"_name": _name,
-		"_type": _type,
-		"_default_value": write_value(_default_value),
+		"_type": _type.get_type_name(),
+		"_default_value": _type.write_value(_default_value),
 		"_category_id": _category_id,
 	}
 	if not _setting_overrides.is_empty():
 		data["_setting_overrides"] = _setting_overrides
 	return data
 
-	
-static func write_value(value:Variant) -> Variant:
-	if value == null:
-		return null
-	if value is Color:
-		var color = value as Color
-		return color.to_html()
-	if value is PandoraReference:
-		return value.save_data()
-	if value is Resource:
-		return value.resource_path
-	return value
-
-
-static func parse_value(value, type:String) -> Variant:
-	if value == null:
-		return null
-	if type == "color" and value is String:
-		return Color.from_string(value, Color.WHITE)
-	if type == "reference" and value is Dictionary:
-		var reference = PandoraReference.new("", 0)
-		reference.load_data(value)
-		return reference
-	if type == "resource" and value is String:
-		return load(value)
-	return value
-	
-	
-static func default_value_of(type:String) -> Variant:
-	if type == "string":
-		return "Property Value"
-	if type == "int":
-		return 0
-	if type == "bool":
-		return false
-	if type == "float":
-		return 0.0
-	if type == "color":
-		return Color.WHITE
-	if type == "reference":
-		return null
-	if type == "resource":
-		return null
-	push_error("Unsupported variant type %s" % str(type))
-	return ""
-
-
-func is_valid_type(variant:Variant) -> bool:
-	if not _type_checks().has(get_property_type()):
-		return false
-	return variant == null or _type_checks()[get_property_type()].call(variant)
-
-
-# FIXME: make this a static in future
-func _type_checks() -> Dictionary:
-	return {
-		"string": func(variant): return variant is String,
-		"int": func(variant): return variant is int,
-		"float": func(variant): return variant is float,
-		"bool": func(variant): return variant is bool,
-		"color": func(variant): return variant is Color or variant is String,
-		"reference": func(variant): return variant is PandoraEntity,
-		"resource": func(variant): return variant is Resource
-	}
-
 
 func _to_string() -> String:
-	return "<PandoraProperty '" + get_property_name() + "' (" + get_property_type() + ")>"
+	return "<PandoraProperty '" + get_property_name() + "' (" + get_property_type().get_type_name() + ")>"

--- a/addons/pandora/model/reference.gd
+++ b/addons/pandora/model/reference.gd
@@ -1,4 +1,4 @@
-class_name PandoraReference extends Resource
+class_name PandoraReference extends RefCounted
 
 
 enum Type {

--- a/addons/pandora/model/type.gd
+++ b/addons/pandora/model/type.gd
@@ -1,0 +1,56 @@
+## This class allows us to make it easier 
+## to specify new types, e.g. by adding a new file 
+## which then internally specifies everything Pandora needs to know,
+## including serialization, property settings and validation.
+class_name PandoraPropertyType extends RefCounted
+
+
+class UndefinedType extends PandoraPropertyType:
+	
+	func _init():
+		super("undefined", {}, null)
+
+
+var _type_name:String
+var _settings:Dictionary
+var _default_value:Variant
+
+
+func _init(type_name:String, settings:Dictionary, default_value:Variant) -> void:
+	self._type_name = type_name
+	self._settings = settings
+	self._default_value = default_value
+	
+	
+func parse_value(variant:Variant) -> Variant:
+	return variant
+	
+	
+func write_value(variant:Variant) -> Variant:
+	return variant
+
+
+func get_type_name() -> String:
+	return _type_name
+
+
+func get_settings() -> Dictionary:
+	return _settings
+
+
+func get_default_value() -> Variant:
+	return _default_value
+	
+	
+func is_valid(variant:Variant) -> bool:
+	return false
+
+
+static func lookup(name:String) -> PandoraPropertyType:
+	if name == "":
+		return UndefinedType.new()
+	var ScriptType = load("res://addons/pandora/model/types/" + name + ".gd")
+	if ScriptType != null and ScriptType.has_source_code():
+		return ScriptType.new()
+	else:
+		return UndefinedType.new()

--- a/addons/pandora/model/types/bool.gd
+++ b/addons/pandora/model/types/bool.gd
@@ -1,0 +1,12 @@
+extends PandoraPropertyType
+
+
+const SETTINGS = {}
+
+
+func _init() -> void:
+	super("bool", SETTINGS, false)
+
+
+func is_valid(variant:Variant) -> bool:
+	return variant is bool

--- a/addons/pandora/model/types/color.gd
+++ b/addons/pandora/model/types/color.gd
@@ -1,0 +1,23 @@
+extends PandoraPropertyType
+
+
+const SETTINGS = {}
+
+
+func _init() -> void:
+	super("color", SETTINGS, Color.WHITE)
+
+
+func parse_value(variant:Variant) -> Variant:
+	if variant is String:
+		return Color.from_string(variant, Color.WHITE)
+	return variant
+	
+	
+func write_value(variant:Variant) -> Variant:
+	var color = variant as Color
+	return color.to_html()
+
+
+func is_valid(variant:Variant) -> bool:
+	return variant is Color or variant is String

--- a/addons/pandora/model/types/float.gd
+++ b/addons/pandora/model/types/float.gd
@@ -1,0 +1,29 @@
+extends PandoraPropertyType
+
+const SETTING_MIN_VALUE = "Min Value"
+const SETTING_MAX_VALUE = "Max Value"
+const SETTING_STEPS = "Steps"
+
+
+const SETTINGS = {
+		SETTING_STEPS: {
+			"type": "float",
+			"value": 0.01
+		},
+		SETTING_MIN_VALUE: {
+			"type": "int",
+			"value": -9999999999
+		},
+		SETTING_MAX_VALUE: {
+			"type": "int",
+			"value": 9999999999
+		}
+	}
+
+
+func _init() -> void:
+	super("float", SETTINGS, 0.0)
+
+
+func is_valid(variant:Variant) -> bool:
+	return variant is float

--- a/addons/pandora/model/types/int.gd
+++ b/addons/pandora/model/types/int.gd
@@ -1,0 +1,31 @@
+extends PandoraPropertyType
+
+
+const SETTING_MIN_VALUE = "Min Value"
+const SETTING_MAX_VALUE = "Max Value"
+
+
+const SETTINGS = {
+		SETTING_MIN_VALUE: {
+			"type": "int",
+			"value": -9999999999
+		},
+		SETTING_MAX_VALUE: {
+			"type": "int",
+			"value": 9999999999
+		}
+	}
+
+
+func _init() -> void:
+	super("int", SETTINGS, 0)
+
+
+func parse_value(variant:Variant) -> Variant:
+	if variant is float:
+		return int(variant)
+	return variant
+
+
+func is_valid(variant:Variant) -> bool:
+	return variant is int

--- a/addons/pandora/model/types/reference.gd
+++ b/addons/pandora/model/types/reference.gd
@@ -1,0 +1,50 @@
+extends PandoraPropertyType
+
+
+const SETTING_CATEGORIES_ONLY = "Categories Only"
+const SETTING_CATEGORY_FILTER = "Category Filter"
+const SETTING_SORT_LIST = "Sort List"
+const SORT_ALPHABETICALLY = "Alphabetically"
+const SORT_AS_IS = "As-Is"
+
+
+const SETTINGS = {
+		SETTING_CATEGORIES_ONLY: {
+			"type": "bool",
+			"value": false
+		},
+		SETTING_CATEGORY_FILTER: {
+			"type": "reference",
+			"value": ""
+		},
+		SETTING_SORT_LIST: {
+			"type": "string",
+			"options": [
+				SORT_ALPHABETICALLY,
+				SORT_AS_IS
+			],
+			"value": SORT_ALPHABETICALLY
+		}
+	}
+
+
+func _init() -> void:
+	super("reference", SETTINGS, null)
+
+
+func parse_value(variant:Variant) -> Variant:
+	if variant is Dictionary:
+		var reference = PandoraReference.new("", 0)
+		reference.load_data(variant)
+		return reference
+	return variant
+
+
+func write_value(variant:Variant) -> Variant:
+	if variant is PandoraReference:
+		return variant.save_data()
+	return variant
+
+
+func is_valid(variant:Variant) -> bool:
+	return variant is PandoraEntity

--- a/addons/pandora/model/types/resource.gd
+++ b/addons/pandora/model/types/resource.gd
@@ -1,0 +1,24 @@
+extends PandoraPropertyType
+
+
+const SETTINGS = {}
+
+
+func _init() -> void:
+	super("resource", SETTINGS, null)
+
+
+func parse_value(variant:Variant) -> Variant:
+	if variant is String:
+		return load(variant)
+	return variant
+	
+	
+func write_value(variant:Variant) -> Variant:
+	if variant is Resource:
+		return variant.resource_path
+	return variant
+
+
+func is_valid(variant:Variant) -> bool:
+	return variant is Resource

--- a/addons/pandora/model/types/string.gd
+++ b/addons/pandora/model/types/string.gd
@@ -1,0 +1,12 @@
+extends PandoraPropertyType
+
+
+const SETTINGS = {}
+
+
+func _init() -> void:
+	super("string", SETTINGS, "")
+
+
+func is_valid(variant:Variant) -> bool:
+	return variant is String

--- a/addons/pandora/ui/components/properties/float/float_property.gd
+++ b/addons/pandora/ui/components/properties/float/float_property.gd
@@ -2,9 +2,7 @@
 extends PandoraPropertyControl
 
 
-const MIN_VALUE = "Min Value"
-const MAX_VALUE = "Max Value"
-const STEPS = "Steps"
+const FloatType = preload("res://addons/pandora/model/types/float.gd")
 
 
 @onready var spin_box: SpinBox = $SpinBox
@@ -26,28 +24,11 @@ func _ready() -> void:
 func refresh() -> void:
 	spin_box.rounded = false
 	spin_box.value = _property.get_default_value() as float
-	spin_box.min_value = _get_setting(MIN_VALUE) as int
-	spin_box.max_value = _get_setting(MAX_VALUE) as int
-	spin_box.step = _get_setting(STEPS) as float
-
-
-func get_default_settings() -> Dictionary:
-	return {
-		STEPS: {
-			"type": "float",
-			"value": 0.01
-		},
-		MIN_VALUE: {
-			"type": "int",
-			"value": -9999999999
-		},
-		MAX_VALUE: {
-			"type": "int",
-			"value": 9999999999
-		}
-	}
+	spin_box.min_value = _property.get_setting(FloatType.SETTING_MIN_VALUE) as int
+	spin_box.max_value = _property.get_setting(FloatType.SETTING_MAX_VALUE) as int
+	spin_box.step = _property.get_setting(FloatType.SETTING_STEPS) as float
 
 
 func _setting_changed(key:String) -> void:
-	if key == MIN_VALUE || key == MAX_VALUE || key == STEPS:
+	if key == FloatType.SETTING_MIN_VALUE || key == FloatType.SETTING_MAX_VALUE || key == FloatType.SETTING_STEPS:
 		refresh()

--- a/addons/pandora/ui/components/properties/integer/integer_property.gd
+++ b/addons/pandora/ui/components/properties/integer/integer_property.gd
@@ -1,8 +1,8 @@
 @tool
 extends PandoraPropertyControl
 
-const MIN_VALUE = "Min Value"
-const MAX_VALUE = "Max Value"
+
+const IntType = preload("res://addons/pandora/model/types/int.gd")
 
 
 @onready var spin_box: SpinBox = $SpinBox
@@ -24,23 +24,10 @@ func _ready() -> void:
 func refresh() -> void:
 	if _property != null:
 		spin_box.value = _property.get_default_value() as int
-	spin_box.min_value = _get_setting(MIN_VALUE) as int
-	spin_box.max_value = _get_setting(MAX_VALUE) as int
-
-
-func get_default_settings() -> Dictionary:
-	return {
-		MIN_VALUE: {
-			"type": "int",
-			"value": -9999999999
-		},
-		MAX_VALUE: {
-			"type": "int",
-			"value": 9999999999
-		}
-	}
+	spin_box.min_value = _property.get_setting(IntType.SETTING_MIN_VALUE) as int
+	spin_box.max_value = _property.get_setting(IntType.SETTING_MAX_VALUE) as int
 
 
 func _setting_changed(key:String) -> void:
-	if key == MIN_VALUE || key == MAX_VALUE:
+	if key == IntType.SETTING_MIN_VALUE || key == IntType.SETTING_MAX_VALUE:
 		refresh()

--- a/addons/pandora/ui/components/properties/property_control.gd
+++ b/addons/pandora/ui/components/properties/property_control.gd
@@ -19,14 +19,3 @@ func init(property:PandoraProperty) -> void:
 	
 func refresh() -> void:
 	pass
-
-
-func get_default_settings() -> Dictionary:
-	return {}
-
-
-func _get_setting(key:String) -> Variant:
-	if _property.has_setting_override(key):
-		return _property.get_setting_override(key)
-	else:
-		return get_default_settings()[key]["value"]

--- a/addons/pandora/ui/components/properties/property_control_kvp.gd
+++ b/addons/pandora/ui/components/properties/property_control_kvp.gd
@@ -6,7 +6,7 @@ extends PanelContainer
 signal inherited_property_selected(category_id:String, property_name:String)
 
 ## called when an original property was selected
-signal original_property_selected(property:PandoraProperty, default_settings:Dictionary)
+signal original_property_selected(property:PandoraProperty)
 
 
 var _property:PandoraProperty:
@@ -105,7 +105,7 @@ func _delete_property() -> void:
 	
 
 func _property_key_focused() -> void:
-	original_property_selected.emit(_property, _control.get_default_settings())
+	original_property_selected.emit(_property)
 
 
 func _property_key_unfocused() -> void:
@@ -114,7 +114,7 @@ func _property_key_unfocused() -> void:
 
 func _control_value_focused() -> void:
 	if property_key_edit.visible:
-		original_property_selected.emit(_property, _control.get_default_settings())
+		original_property_selected.emit(_property)
 		
 	
 func _control_value_unfocused() -> void:

--- a/addons/pandora/ui/components/properties/reference/reference_property.gd
+++ b/addons/pandora/ui/components/properties/reference/reference_property.gd
@@ -2,12 +2,7 @@
 extends PandoraPropertyControl
 
 
-const CATEGORY_FILTER = "Category Filter"
-const CATEGORIES_ONLY = "Categories Only"
-const SORT_LIST = "Sort List"
-
-const SORT_ALPHABETICALLY = "Alphabetically"
-const SORT_AS_IS = "As-Is"
+const ReferenceType = preload("res://addons/pandora/model/types/reference.gd")
 
 
 @onready var entity_picker = $EntityPicker
@@ -27,40 +22,18 @@ func _ready() -> void:
 
 func refresh() -> void:
 	if _property != null:
-		entity_picker.set_filter(_get_setting(CATEGORY_FILTER) as String)
-		entity_picker.categories_only = _get_setting(CATEGORIES_ONLY) as bool
-		match _get_setting(SORT_LIST) as String:
-			SORT_ALPHABETICALLY:
+		entity_picker.set_filter(_property.get_setting(ReferenceType.SETTING_CATEGORY_FILTER) as String)
+		entity_picker.categories_only = _property.get_setting(ReferenceType.SETTING_CATEGORIES_ONLY) as bool
+		match _property.get_setting(ReferenceType.SETTING_SORT_LIST) as String:
+			ReferenceType.SORT_ALPHABETICALLY:
 				entity_picker.set_sort(func(a,b): return a.get_entity_name() < b.get_entity_name())
-			SORT_AS_IS:
+			ReferenceType.SORT_AS_IS:
 				entity_picker.set_sort(func(a,b): return false)
 		var entity = _property.get_default_value() as PandoraEntity
 		if entity != null:
 			entity_picker.select.call_deferred(entity)
-
-
-
-func get_default_settings() -> Dictionary:
-	return {
-		CATEGORIES_ONLY: {
-			"type": "bool",
-			"value": false
-		},
-		CATEGORY_FILTER: {
-			"type": "reference",
-			"value": ""
-		},
-		SORT_LIST: {
-			"type": "string",
-			"options": [
-				SORT_ALPHABETICALLY,
-				SORT_AS_IS
-			],
-			"value": SORT_ALPHABETICALLY
-		}
-	}
 	
 	
 func _setting_changed(key:String) -> void:
-	if key == CATEGORIES_ONLY || key == CATEGORY_FILTER || key == SORT_LIST:
+	if key == ReferenceType.SETTING_CATEGORIES_ONLY || key == ReferenceType.SETTING_CATEGORY_FILTER || key == ReferenceType.SETTING_SORT_LIST:
 		refresh()

--- a/addons/pandora/ui/editor/property_editor/property_editor.gd
+++ b/addons/pandora/ui/editor/property_editor/property_editor.gd
@@ -36,7 +36,7 @@ func edit_key(property_name:String) -> void:
 
 func set_entity(entity:PandoraEntity) -> void:
 	property_settings_container.visible = entity is PandoraCategory
-	property_settings_container.set_property(null, {})
+	property_settings_container.set_property(null)
 	for child in property_list.get_children():
 		child.queue_free()
 	self.current_entity = entity
@@ -50,7 +50,7 @@ func set_entity(entity:PandoraEntity) -> void:
 		var properties = entity.get_entity_properties()
 		
 		for property in properties:
-			var scene = property_bar.get_scene_by_type(property.get_property_type())
+			var scene = property_bar.get_scene_by_type(property.get_property_type().get_type_name())
 			var control = scene.instantiate() as PandoraPropertyControl
 			_add_property_control(control, property)
 

--- a/addons/pandora/ui/editor/property_settings_editor/property_settings_editor.gd
+++ b/addons/pandora/ui/editor/property_settings_editor/property_settings_editor.gd
@@ -15,23 +15,23 @@ var _default_settings:Dictionary
 
 
 
-func set_property(property:PandoraProperty, default_settings:Dictionary) -> void:
+func set_property(property:PandoraProperty) -> void:
 	for child in properties_settings.get_children():
 		child.queue_free()
 	properties_settings.get_children().clear()
 	self._property = property
-	self._default_settings = default_settings
+	self._default_settings = property.get_property_type().get_settings() if property != null else {}
 	info_label.visible = property == null or not property.is_original()
 	header_label.visible = not info_label.visible
 
-	for default_setting_name in default_settings:
+	for default_setting_name in _default_settings:
 		var setting = HBoxContainer.new()
 		setting.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		var label = Label.new()
 		label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		label.text = default_setting_name
 		setting.add_child(label)
-		var default_setting = default_settings[default_setting_name]
+		var default_setting = _default_settings[default_setting_name]
 		var current_value = _property.get_setting_override(default_setting_name) if _property.has_setting_override(default_setting_name) else default_setting.value
 		var options:Array[Variant] = []
 		options.assign(default_setting["options"] if default_setting.has("options") else [])

--- a/docs/contribute/adding-new-property.md
+++ b/docs/contribute/adding-new-property.md
@@ -2,19 +2,36 @@
 
 In this section you will learn how to introduce new property types to Pandora. [Refer to these docs](http://localhost:3000/#/concepts/properties/) to see a list of all currently available properties.
 
-## Step 1: Make `PandoraProperty` aware of new type
+## Step 1: Add new subclass of `PandoraPropertyType`
 
-Head to `res://addons/pandora/model/property.gd` and open up the file. The `PandoraProperty` is responsible for storing and providing property information to Godot. This type has a few responsibilities:
+Head to `res://addons/pandora/model/types` and create a new script with the name of your type that extends `PandoraPropertyType`:
+```gdscript
+extends PandoraPropertyType
 
-- define what properties are valid
-- define how to load/read properties from json
-- provide methods to access and update the property values via GDScript
+const SETTINGS = {}
 
-Search for the `_type_checks()` method that defines which variants are actually valid and allowed by Pandora. Add your new type there. Make sure you choose a name for your property type that is concise and makes sense.
 
-> `Dictionary` and `Array` may be special cases here, e.g. an `Array` may still be of type `reference` but instead of a single value, its `Variant` is an array of references.
+func _init() -> void:
+   super("identifier", SETTINGS, null)
+```
+The parent `_init()` function takes the following parameters:
 
-Also ensure to define a default value if deemed necessary in this script. Further up you will find methods regarding parsing and writing data - some properties like `"color"` need to be stored somehow to JSON, which is handled there.
+- the `name` of a type, e.g. `"identifier"` with which the type is identified across Pandora
+- the `settings` this type provides - this is especially useful if you want to make this type customizable
+- the `default` value that this type provides, in case the user does not specify one.
+
+### Validation
+
+Ensure to override the `is_valid(variant:Variant)` method to ensure variants used in combination with this type are valid, e.g.:
+```gdscript
+func is_valid(variant:Variant) -> bool:
+   # ensures only arrays are supported
+   return variant is Array
+```
+
+### Parsing & Saving
+
+Some types require custom parsing - e.g. inside Pandora, the `"color"` type variant is of type `Color` - however, it gets stored as its HTML representation to disk. Override the `parse_value` (reading from file) and `write_value` (writing to file) functions to customise serialization.
 
 ## Step 2: Build Property Picker Component
 

--- a/test/model/property_test.gd
+++ b/test/model/property_test.gd
@@ -10,109 +10,124 @@ const __source = "res://addons/pandora/model/property.gd"
 
 
 func test_string_property() -> void:
-	var property = PandoraProperty.new("123", "property", "string", "Hello World")
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "string")
+	property.set_default_value("Hello World")
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
 	assert_that(new_property).is_equal(property)
 	
 	
 func test_string_property_wrong_type() -> void:
-	var property = PandoraProperty.new("123", "property", "reference", "Hello World")
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "reference")
+	property.set_default_value("Hello World")
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
 	assert_that(new_property.get_default_value()).is_null()
 	
 	
 func test_int_property() -> void:
-	var property = PandoraProperty.new("123", "property", "int", 123)
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "int")
+	property.set_default_value(123)
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
 	assert_that(new_property).is_equal(property)
 	
 	
 func test_int_property_wrong_type() -> void:
-	var property = PandoraProperty.new("123", "property", "string", 123)
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "string")
+	property.set_default_value(123)
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
-	assert_that(new_property.get_default_value()).is_null()
+	assert_that(new_property.get_default_value()).is_equal("")
 	
 	
 func test_bool_property() -> void:
-	var property = PandoraProperty.new("123", "property", "bool", true)
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "bool")
+	property.set_default_value(true)
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
 	assert_that(new_property).is_equal(property)
 	
 	
 func test_bool_property_wrong_type() -> void:
-	var property = PandoraProperty.new("123", "property", "float", true)
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "float")
+	property.set_default_value(false)
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
-	assert_that(new_property.get_default_value()).is_null()
+	assert_that(new_property.get_default_value()).is_equal(0.0)
 	
 	
 func test_float_property() -> void:
-	var property = PandoraProperty.new("123", "property", "float", 1.23)
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "float")
+	property.set_default_value(10.3)
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
 	assert_that(new_property).is_equal(property)
 	
 	
 func test_float_property_wrong_type() -> void:
-	var property = PandoraProperty.new("123", "property", "int", 1.23)
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "int")
+	property.set_default_value(1.23)
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
-	assert_that(new_property.get_default_value()).is_null()
+	assert_that(new_property.get_default_value()).is_equal(0)
 	
 	
 func test_color_property() -> void:
-	var property = PandoraProperty.new("123", "property", "color", Color.RED)
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "color")
+	property.set_default_value(Color.RED)
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
 	assert_that(new_property).is_equal(property)
 	
 	
 func test_color_property_wrong_type() -> void:
-	var property = PandoraProperty.new("123", "property", "reference", Color.RED)
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "reference")
+	property.set_default_value(Color.RED)
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
 	assert_that(new_property.get_default_value()).is_null()
 	
 	
 func test_reference_property() -> void:
 	var ref = PandoraReference.new("12345", 0)
-	var property = PandoraProperty.new("123", "property", "reference", ref)
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "reference")
+	property.set_default_value(ref)
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
 	assert_that(new_property).is_equal(property)
 	
 	
 func test_reference_property_wrong_type() -> void:
 	var ref = PandoraReference.new("12345", 0)
-	var property = PandoraProperty.new("123", "property", "bool", ref)
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "bool")
+	property.set_default_value(ref)
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
-	assert_that(new_property.get_default_value()).is_null()
+	assert_bool(new_property.get_default_value()).is_false()
 	
 	
 func test_unknown_type() -> void:
-	var property = PandoraProperty.new("123", "property", "unknown", "123")
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "unknown")
+	property.set_default_value( "123")
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
 	assert_that(new_property.get_default_value()).is_null()
 	
 	
 func test_resource_property() -> void:
 	var resource = load("res://splash.png")
-	var property = PandoraProperty.new("123", "property", "resource", resource)
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "resource")
+	property.set_default_value(resource)
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
 	assert_that(new_property).is_equal(property)
 	
 	
 func test_resource_property_wrong_type() -> void:
 	var resource = load("res://splash.png")
-	var property = PandoraProperty.new("123", "property", "string", resource)
-	var new_property = PandoraProperty.new("", "", "", "")
+	var property = PandoraProperty.new("123", "property", "string")
+	property.set_default_value(resource)
+	var new_property = PandoraProperty.new("", "", "")
 	new_property.load_data(property.save_data())
-	assert_that(new_property.get_default_value()).is_null()
+	assert_that(new_property.get_default_value()).is_equal("")

--- a/test/ui/editor/property_settings_editor/property_settings_editor_test.gd
+++ b/test/ui/editor/property_settings_editor/property_settings_editor_test.gd
@@ -53,12 +53,12 @@ func test_create_settings_ui() -> void:
 	var id_generator = PandoraIdGenerator.new()
 	var backend = PandoraEntityBackend.new(id_generator)
 	var root_category = backend.create_category("root")
-	var property = backend.create_property(root_category, "Weight", "float")
+	var property = backend.create_property(root_category, "Weight", "reference")
 	var control = auto_free(load(__source).instantiate())
 	var runner = scene_runner(control)
-	control.set_property(property, EXAMPLE_SETTINGS)
+	control.set_property(property)
 	
-	assert_that(control.properties_settings.get_child_count()).is_equal(7)
+	assert_that(control.properties_settings.get_child_count()).is_equal(3)
 	
 	
 	


### PR DESCRIPTION
### Prerequisite for:

- https://github.com/bitbrain/pandora/issues/95
- https://github.com/bitbrain/pandora/issues/54
- https://github.com/bitbrain/pandora/issues/22

## Description

Complete overhaul of the type system of Pandora by introducing the `PandoraPropertyType` class. This allows us to make it easier to specify new types, e.g. by adding a new file to `res://addons/pandora/model/types/new-type.gd` which then internally specifies everything Pandora needs to know, including serialization, property settings and validation!

## Highlights

- removed type settings from UI code
- remove type parsing responsibility from `PandoraProperty` and move it over into `PandoraPropertyType` - instead, it now acts as a "stupid" container
- clean up some areas, e.g. `PandoraProperty` now gets its default value from the type, rather than having to pass it in manually
- updated documentation to reflect the changes

Functionally, this pull request should not change anything critically.