### PR TITLE
📦 use uncompressed data during debug mode

### DIFF
--- a/addons/pandora/storage/json/json_data_storage.gd
+++ b/addons/pandora/storage/json/json_data_storage.gd
@@ -21,7 +21,7 @@ func _init(data_dir: String):
 
 func store_all_data(data:Dictionary, context_id: String) -> Dictionary:
 	var file_path = _get_file_path(context_id)
-	var file : FileAccess
+	var file: FileAccess
 	if OS.is_debug_build():
 		file = FileAccess.open(file_path, FileAccess.WRITE)
 		file.store_string(JSON.stringify(data, "\t"))
@@ -34,12 +34,12 @@ func store_all_data(data:Dictionary, context_id: String) -> Dictionary:
 
 func get_all_data(context_id: String) -> Dictionary:
 	var file_path = _get_file_path(context_id)
-	var file : FileAccess
+	var file: FileAccess
 	if OS.is_debug_build():
 		file = FileAccess.open(file_path, FileAccess.READ)
 	else:
 		file = FileAccess.open_compressed(file_path, FileAccess.READ)
-	var json : JSON = JSON.new()
+	var json: JSON = JSON.new()
 	if file != null:
 		var text = file.get_as_text()
 		json.parse(text)
@@ -53,11 +53,11 @@ func get_all_data(context_id: String) -> Dictionary:
 		return {}
 
 func get_decompressed_data(file_path : String) -> Dictionary:
-	var file : FileAccess = FileAccess.open_compressed(file_path, FileAccess.READ)
+	var file: FileAccess = FileAccess.open_compressed(file_path, FileAccess.READ)
 	if file != null:
 		var text = file.get_as_text()
 		file.close()
-		var json : JSON = JSON.new()
+		var json: JSON = JSON.new()
 		json.parse(text)
 		return json.get_data() as Dictionary
 	else:
@@ -80,7 +80,7 @@ func _get_file_path(context_id: String) -> String:
 
 
 func _load_from_file(file_path: String) -> Dictionary:
-	var file : FileAccess
+	var file: FileAccess
 	if OS.is_debug_build():
 		file = FileAccess.open(file_path, FileAccess.READ)
 	else:

--- a/addons/pandora/storage/json/json_data_storage.gd
+++ b/addons/pandora/storage/json/json_data_storage.gd
@@ -45,7 +45,7 @@ func get_all_data(context_id: String) -> Dictionary:
 		json.parse(text)
 		file.close()
 		# Backwards compatibility for already compressed files
-		if !json.get_data() and OS.is_debug_build():
+		if not json.get_data() and OS.is_debug_build():
 			print("Compressed file detected in debug mode, decompressing...")
 			return get_decompressed_data(file_path)
 		return json.get_data() as Dictionary

--- a/addons/pandora/storage/json/json_data_storage.gd
+++ b/addons/pandora/storage/json/json_data_storage.gd
@@ -21,21 +21,44 @@ func _init(data_dir: String):
 
 func store_all_data(data:Dictionary, context_id: String) -> Dictionary:
 	var file_path = _get_file_path(context_id)
-	var file = FileAccess.open_compressed(file_path, FileAccess.WRITE)
-	var json = JSON.new()
-	file.store_string(json.stringify(data))
+	var file : FileAccess
+	if OS.is_debug_build():
+		file = FileAccess.open(file_path, FileAccess.WRITE)
+		file.store_string(JSON.stringify(data, "\t"))
+	else:
+		file = FileAccess.open_compressed(file_path, FileAccess.WRITE)
+		file.store_string(JSON.stringify(data))
 	file.close()
 	return data
 
 
 func get_all_data(context_id: String) -> Dictionary:
 	var file_path = _get_file_path(context_id)
-	var file = FileAccess.open_compressed(file_path, FileAccess.READ)
-	var json = JSON.new()
+	var file : FileAccess
+	if OS.is_debug_build():
+		file = FileAccess.open(file_path, FileAccess.READ)
+	else:
+		file = FileAccess.open_compressed(file_path, FileAccess.READ)
+	var json : JSON = JSON.new()
 	if file != null:
 		var text = file.get_as_text()
 		json.parse(text)
 		file.close()
+		# Backwards compatibility for already compressed files
+		if !json.get_data() and OS.is_debug_build():
+			print("Compressed file detected in debug mode, decompressing...")
+			return get_decompressed_data(file_path)
+		return json.get_data() as Dictionary
+	else:
+		return {}
+
+func get_decompressed_data(file_path : String) -> Dictionary:
+	var file : FileAccess = FileAccess.open_compressed(file_path, FileAccess.READ)
+	if file != null:
+		var text = file.get_as_text()
+		file.close()
+		var json : JSON = JSON.new()
+		json.parse(text)
 		return json.get_data() as Dictionary
 	else:
 		return {}
@@ -57,7 +80,11 @@ func _get_file_path(context_id: String) -> String:
 
 
 func _load_from_file(file_path: String) -> Dictionary:
-	var file = FileAccess.open_compressed(file_path, FileAccess.READ)
+	var file : FileAccess
+	if OS.is_debug_build():
+		file = FileAccess.open(file_path, FileAccess.READ)
+	else:
+		file = FileAccess.open_compressed(file_path, FileAccess.READ)
 	if FileAccess.file_exists(file_path) and file != null:
 		var content = file.get_as_text()
 		file.close()

--- a/addons/pandora/storage/json/json_data_storage.gd
+++ b/addons/pandora/storage/json/json_data_storage.gd
@@ -45,7 +45,7 @@ func get_all_data(context_id: String) -> Dictionary:
 		json.parse(text)
 		file.close()
 		# Backwards compatibility for already compressed files
-		if not json.get_data() and OS.is_debug_build():
+		if json.get_data() == null and OS.is_debug_build():
 			print("Compressed file detected in debug mode, decompressing...")
 			return get_decompressed_data(file_path)
 		return json.get_data() as Dictionary


### PR DESCRIPTION
## Description

As discussed in #64, working with uncompressed ```data.pandora``` file during development would not only allow us to inspect data manually in editors for debugging but also eases git conflict resolutions when collaborating in a project with multiple developers.

## Addressed issues

- #64 

## Main Changes

- Debug: The data.pandora file will be saved in a 'Pretty Printed' JSON format, uncompressed. This facilitates easier debugging and manual data inspection.
- Release: The data.pandora file will be saved in a compressed format to ensure optimal performance in production.

I also implemented measures to ensure that existing data.pandora files are compatible and prevent any potential reading issues.
