### PR TITLE
:sparkles: duplicate entity instance functionality

### DIFF
--- a/addons/pandora/model/entity.gd
+++ b/addons/pandora/model/entity.gd
@@ -163,6 +163,19 @@ func init_entity(id:String, name:String, icon_path:String, category_id:String) -
 	self._category_id = category_id
 
 
+## Similar to instantiate(), this method will duplicate an existing
+## instance with all its properties.
+## In case this is called on an entity, it will act as instantiate()
+func duplicate_instance() -> PandoraEntity:
+	var new_instance = instantiate()
+	# ensure to carry over any overrides!
+	if is_instance():
+		for key in _instance_properties:
+			var duplicated_property = _instance_properties[key].duplicate_instance()
+			new_instance._instance_properties[key] = duplicated_property
+	return new_instance
+
+
 ## Creates an instance of this entity.
 func instantiate() -> PandoraEntity:
 	var entity = ScriptUtil.create_entity_from_script(get_script_path(), "", "", "", "")

--- a/addons/pandora/model/property_instance.gd
+++ b/addons/pandora/model/property_instance.gd
@@ -14,6 +14,10 @@ func _init(_property:PandoraProperty, value:Variant) -> void:
 	self._property = _property
 	
 	
+func duplicate_instance() -> PandoraPropertyInstance:
+	return PandoraPropertyInstance.new(_property, _value)
+
+	
 func get_property_name() -> String:
 	if _property != null:
 		return _property.get_property_name()

--- a/test/backend/entity_backend_test.gd
+++ b/test/backend/entity_backend_test.gd
@@ -707,3 +707,28 @@ func test_icon_color_overridden() -> void:
 	entity.set_icon_color(Color.BLUE)
 	category.set_icon_color(Color.RED)
 	assert_that(entity.get_icon_color()).is_equal(Color.BLUE)
+
+
+func test_duplicate_entity_instance_inherits_original() -> void:
+	var backend = create_object_backend()
+	var category = backend.create_category("Category")
+	var entity = backend.create_entity("Entity", category)
+	backend.create_property(category, "test", "string", "")
+	var instance = entity.instantiate()
+	instance.set_string("test", "original-instance")
+	var duplicate = instance.duplicate_instance()
+	assert_that(duplicate.get_string('test')).is_equal("original-instance")
+	
+	
+func test_duplicate_entity_instance_is_independent_of_former() -> void:
+	var backend = create_object_backend()
+	var category = backend.create_category("Category")
+	var entity = backend.create_entity("Entity", category)
+	backend.create_property(category, "test", "string", "")
+	var instance = entity.instantiate()
+	instance.set_string("test", "original-instance")
+	var duplicate = instance.duplicate_instance()
+	duplicate.set_string("test", "duplicate-instance")
+	assert_that(instance.get_string('test')).is_equal("original-instance")
+	assert_that(duplicate.get_string('test')).is_equal("duplicate-instance")
+	

--- a/test/model/entity_test.gd
+++ b/test/model/entity_test.gd
@@ -1,0 +1,31 @@
+# GdUnit generated TestSuite
+class_name EntityTest
+extends GdUnitTestSuite
+@warning_ignore("unused_parameter")
+@warning_ignore("return_value_discarded")
+
+
+# TestSuite generated from
+const __source = "res://addons/pandora/model/entity.gd"
+
+
+func test_init_entity() -> void:
+	var entity = PandoraEntity.new()
+	entity.init_entity("123", "Test Entity", "res://hello.jpg", "123")
+	assert_that(entity.get_entity_id()).is_equal("123")
+	
+	
+func test_instantiate_entity() -> void:
+	var entity = PandoraEntity.new()
+	entity.init_entity("123", "Test Entity", "res://hello.jpg", "123")
+	var instance = entity.instantiate()
+	assert_that(instance.get_entity_id()).is_equal("123")
+	assert_bool(instance.is_instance()).is_true()
+	
+	
+func test_duplicate_entity() -> void:
+	var entity = PandoraEntity.new()
+	entity.init_entity("123", "Test Entity", "res://hello.jpg", "123")
+	var instance = entity.duplicate_instance()
+	assert_that(instance.get_entity_id()).is_equal("123")
+	assert_bool(instance.is_instance()).is_true()


### PR DESCRIPTION
## Description

Sometimes we want to duplicate entities, e.g. when having self-multiplying enemies in the world that already have a custom state. This can be achieved as follows via this PR:
```gdscript
var entity = Pandora.get_entity("123")
var entity_instance = entity.instantiate()
var duplicate_instance = entity_instance.duplicate_instance()
```
Additionally, you can also call `duplicate_instance()` on non-instances to create new instances (acts as `instantiate()`).

_Note: the new method is called `duplicate_instance()` and not `duplicate()` as that method is already reserved for traditional Godot resources. It has some different meaning/docs so I did not want to mix up these concepts!_