### PR TITLE
Add max width to entity icons in tree

### DIFF
--- a/addons/pandora/plugin.gd
+++ b/addons/pandora/plugin.gd
@@ -49,6 +49,8 @@ func _exit_tree() -> void:
 		editor_view.queue_free()
 		remove_inspector_plugin(entity_inspector)
 	
+	Engine.remove_meta("PandoraEditorPlugin")
+	
 	remove_export_plugin(_exporter)
 	remove_autoload_singleton("Pandora")
 

--- a/addons/pandora/ui/components/entity_picker/entity_picker.gd
+++ b/addons/pandora/ui/components/entity_picker/entity_picker.gd
@@ -53,7 +53,8 @@ func set_data(entities:Array[PandoraEntity]) -> void:
 		option_button.get_popup().add_icon_item(load(entity.get_icon_path()), entity.get_entity_name(), id_counter)
 		
 		var editor_plugin: EditorPlugin = Engine.get_meta("PandoraEditorPlugin")
-		option_button.get_popup().set_item_icon_max_width(id_counter, editor_plugin.get_editor_interface().get_editor_scale() * 16)
+		if editor_plugin:
+			option_button.get_popup().set_item_icon_max_width(id_counter, editor_plugin.get_editor_interface().get_editor_scale() * 16)
 		# Godot 4.1+
 		if option_button.get_popup().has_method("set_item_icon_modulate"):
 			option_button.get_popup().set_item_icon_modulate(id_counter, entity.get_icon_color())

--- a/addons/pandora/ui/components/entity_picker/entity_picker.gd
+++ b/addons/pandora/ui/components/entity_picker/entity_picker.gd
@@ -52,7 +52,7 @@ func set_data(entities:Array[PandoraEntity]) -> void:
 	for entity in _entities:
 		option_button.get_popup().add_icon_item(load(entity.get_icon_path()), entity.get_entity_name(), id_counter)
 		
-		var editor_plugin: EditorPlugin = Engine.get_meta("PandoraEditorPlugin")
+		var editor_plugin: EditorPlugin = Engine.get_meta("PandoraEditorPlugin") if Engine.has_meta("PandoraEditorPlugin") else null
 		if editor_plugin:
 			option_button.get_popup().set_item_icon_max_width(id_counter, editor_plugin.get_editor_interface().get_editor_scale() * 16)
 		# Godot 4.1+

--- a/addons/pandora/ui/components/entity_picker/entity_picker.gd
+++ b/addons/pandora/ui/components/entity_picker/entity_picker.gd
@@ -51,6 +51,9 @@ func set_data(entities:Array[PandoraEntity]) -> void:
 	option_button.get_popup().clear()
 	for entity in _entities:
 		option_button.get_popup().add_icon_item(load(entity.get_icon_path()), entity.get_entity_name(), id_counter)
+		
+		var editor_plugin: EditorPlugin = Engine.get_meta("PandoraEditorPlugin")
+		option_button.get_popup().set_item_icon_max_width(id_counter, editor_plugin.get_editor_interface().get_editor_scale() * 16)
 		# Godot 4.1+
 		if option_button.get_popup().has_method("set_item_icon_modulate"):
 			option_button.get_popup().set_item_icon_modulate(id_counter, entity.get_icon_color())

--- a/addons/pandora/ui/components/entity_picker/entity_picker.tscn
+++ b/addons/pandora/ui/components/entity_picker/entity_picker.tscn
@@ -14,3 +14,4 @@ script = ExtResource("1_cjsnj")
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
+expand_icon = true

--- a/addons/pandora/ui/components/entity_tree/entity_tree.gd
+++ b/addons/pandora/ui/components/entity_tree/entity_tree.gd
@@ -163,7 +163,7 @@ func _create_item(parent_item: TreeItem, entity:PandoraEntity) -> TreeItem:
 	item.set_tooltip_text(0, "Entity ID: " + entity.get_entity_id())
 	if entity.get_icon_path() != "":
 		item.set_icon(0, load(entity.get_icon_path()))
-		item.set_icon_max_width(0, 16)
+		item.set_icon_max_width(0, EditorInterface.get_editor_scale() * 16)
 	item.set_icon_modulate(0, entity.get_icon_color())
 	entity.icon_changed.connect(func(new_path): _on_icon_changed(entity.get_entity_id(), new_path))
 	entity.icon_color_changed.connect(func(new_color): _on_icon_color_changed(entity.get_entity_id(), new_color))

--- a/addons/pandora/ui/components/entity_tree/entity_tree.gd
+++ b/addons/pandora/ui/components/entity_tree/entity_tree.gd
@@ -163,6 +163,7 @@ func _create_item(parent_item: TreeItem, entity:PandoraEntity) -> TreeItem:
 	item.set_tooltip_text(0, "Entity ID: " + entity.get_entity_id())
 	if entity.get_icon_path() != "":
 		item.set_icon(0, load(entity.get_icon_path()))
+		item.set_icon_max_width(0, 16)
 	item.set_icon_modulate(0, entity.get_icon_color())
 	entity.icon_changed.connect(func(new_path): _on_icon_changed(entity.get_entity_id(), new_path))
 	entity.icon_color_changed.connect(func(new_color): _on_icon_color_changed(entity.get_entity_id(), new_color))

--- a/addons/pandora/ui/components/entity_tree/entity_tree.gd
+++ b/addons/pandora/ui/components/entity_tree/entity_tree.gd
@@ -172,7 +172,8 @@ func _create_item(parent_item: TreeItem, entity:PandoraEntity) -> TreeItem:
 	item.set_tooltip_text(0, "Entity ID: " + entity.get_entity_id())
 	if entity.get_icon_path() != "":
 		item.set_icon(0, load(entity.get_icon_path()))
-		item.set_icon_max_width(0, EditorInterface.get_editor_scale() * 16)
+		var editor_plugin: EditorPlugin = Engine.get_meta("PandoraEditorPlugin")
+		item.set_icon_max_width(0, editor_plugin.get_editor_interface().get_editor_scale() * 16)
 	item.set_icon_modulate(0, entity.get_icon_color())
 	entity.icon_changed.connect(func(new_path): _on_icon_changed(entity.get_entity_id(), new_path))
 	entity.icon_color_changed.connect(func(new_color): _on_icon_color_changed(entity.get_entity_id(), new_color))

--- a/addons/pandora/ui/components/entity_tree/entity_tree.gd
+++ b/addons/pandora/ui/components/entity_tree/entity_tree.gd
@@ -173,7 +173,8 @@ func _create_item(parent_item: TreeItem, entity:PandoraEntity) -> TreeItem:
 	if entity.get_icon_path() != "":
 		item.set_icon(0, load(entity.get_icon_path()))
 		var editor_plugin: EditorPlugin = Engine.get_meta("PandoraEditorPlugin")
-		item.set_icon_max_width(0, editor_plugin.get_editor_interface().get_editor_scale() * 16)
+		if editor_plugin:
+			item.set_icon_max_width(0, editor_plugin.get_editor_interface().get_editor_scale() * 16)
 	item.set_icon_modulate(0, entity.get_icon_color())
 	entity.icon_changed.connect(func(new_path): _on_icon_changed(entity.get_entity_id(), new_path))
 	entity.icon_color_changed.connect(func(new_color): _on_icon_color_changed(entity.get_entity_id(), new_color))

--- a/addons/pandora/ui/components/entity_tree/entity_tree.gd
+++ b/addons/pandora/ui/components/entity_tree/entity_tree.gd
@@ -172,7 +172,7 @@ func _create_item(parent_item: TreeItem, entity:PandoraEntity) -> TreeItem:
 	item.set_tooltip_text(0, "Entity ID: " + entity.get_entity_id())
 	if entity.get_icon_path() != "":
 		item.set_icon(0, load(entity.get_icon_path()))
-		var editor_plugin: EditorPlugin = Engine.get_meta("PandoraEditorPlugin")
+		var editor_plugin: EditorPlugin = Engine.get_meta("PandoraEditorPlugin") if Engine.has_meta("PandoraEditorPlugin") else null
 		if editor_plugin:
 			item.set_icon_max_width(0, editor_plugin.get_editor_interface().get_editor_scale() * 16)
 	item.set_icon_modulate(0, entity.get_icon_color())


### PR DESCRIPTION
## Description

Sets max width of tree item icons for entities in tree. This allows using larger scale svg icons without having to scale them just to use them in Pandora.

## Addressed issues

- closes #109 

