### PR TITLE
Improved Confirmation Dialog

### DIFF
--- a/addons/pandora/ui/components/entity_tree/entity_tree.gd
+++ b/addons/pandora/ui/components/entity_tree/entity_tree.gd
@@ -50,9 +50,9 @@ func _search_item_recursive(item: TreeItem, text: String) -> bool:
 
 
 func queue_delete(entity_id:String) -> void:
-	confirm("Confirmation Needed", "Are you sure you want to delete?", func():
-		var item = entity_items[entity_id]
-		var entity = item.get_metadata(0) as PandoraEntity
+	var item = entity_items[entity_id]
+	var entity = item.get_metadata(0) as PandoraEntity
+	confirm("Confirmation Needed", "Are you sure you want to delete '%s'?" % entity.get_entity_name(), func():
 		entity_deletion_issued.emit(entity)
 		if item.get_parent() != null:
 			item.get_parent().remove_child(item)

--- a/addons/pandora/ui/components/entity_tree/entity_tree.tscn
+++ b/addons/pandora/ui/components/entity_tree/entity_tree.tscn
@@ -19,4 +19,5 @@ layout_mode = 1
 
 [node name="ConfirmationDialog" type="ConfirmationDialog" parent="."]
 initial_position = 2
-dialog_text = "Are you sure you want to delete?"
+size = Vector2i(303, 80)
+dialog_text = "Are you sure you want to delete '%s'?"


### PR DESCRIPTION
## Description

When the confirmation dialog pops up from deleting or moving an entity within the Pandora editor, the text within the dialog is left-justified and is not very appealing.

Additionally, when you are trying to delete an entity, the dialog did not display the name of the entity. This can cause confusion with the user especially if they selected the wrong entity to delete without realizing.

## Screenshots

![image](https://github.com/bitbrain/pandora/assets/5606120/76fbca08-7e04-455e-8d79-e4a2ec53a2d0)
