### PR TITLE
Seralization and deserialized of typed properties in array

### DIFF
--- a/addons/pandora/model/type.gd
+++ b/addons/pandora/model/type.gd
@@ -60,11 +60,17 @@ func allow_nesting() -> bool:
 static func lookup(name:String) -> PandoraPropertyType:
 	if name == "":
 		return UndefinedType.new()
-	var ScriptType = load("res://addons/pandora/model/types/" + name + ".gd")
-	if ScriptType != null and ScriptType.has_source_code():
-		return ScriptType.new()
-	else:
-		return UndefinedType.new()
+
+	var klass = PandoraPropertyType
+	var types_dir = klass.resource_path.get_base_dir()
+	var type_path = types_dir + "/types/" + name + ".gd"
+
+	if ResourceLoader.exists(type_path):
+		var ScriptType = load(type_path)
+		if ScriptType != null and ScriptType.has_source_code():
+			return ScriptType.new()
+
+	return UndefinedType.new()
 
 static func get_all_types() -> Array[PandoraPropertyType]:
 	var types:Array[PandoraPropertyType] = []

--- a/addons/pandora/model/types/array.gd
+++ b/addons/pandora/model/types/array.gd
@@ -63,8 +63,8 @@ func write_value(variant:Variant) -> Variant:
 		for i in range(array.size()):
 			var value = array[i]
 			if value is PandoraEntity:
+				value_type =  PandoraPropertyType.lookup("reference")
 				value = PandoraReference.new(value.get_entity_id(), PandoraReference.Type.CATEGORY if value is PandoraCategory else PandoraReference.Type.ENTITY).save_data()
-				value_type = value
 			else:
 				for type in types:
 					if type.is_valid(value):

--- a/addons/pandora/model/types/array.gd
+++ b/addons/pandora/model/types/array.gd
@@ -65,6 +65,9 @@ func write_value(variant:Variant) -> Variant:
 			if value is PandoraEntity:
 				value_type =  PandoraPropertyType.lookup("reference")
 				value = PandoraReference.new(value.get_entity_id(), PandoraReference.Type.CATEGORY if value is PandoraCategory else PandoraReference.Type.ENTITY).save_data()
+			elif value is PandoraReference:
+				value_type =  PandoraPropertyType.lookup("reference")
+				value = value.save_data()
 			else:
 				for type in types:
 					if type.is_valid(value):

--- a/addons/pandora/ui/components/array_editor/array_manager.gd
+++ b/addons/pandora/ui/components/array_editor/array_manager.gd
@@ -72,6 +72,8 @@ func _load_items():
 		elif array_type == 'reference':
 			if value is Dictionary:
 				value = Pandora.get_entity(value["_entity_id"])
+			elif value is PandoraReference:
+				value = value.get_entity()
 		item_property.set_default_value(value)
 		_add_property_control(control, item_property, i)
 

--- a/test/backend/entity_backend_test.gd
+++ b/test/backend/entity_backend_test.gd
@@ -249,11 +249,7 @@ func test_save_and_load_data() -> void:
 	backend.create_entity("b", category_b)
 	backend.create_property(category_c, "property1", "string", "Hello World")
 	backend.create_property(category_d, "typed_array", "array", [Color.RED])
-
-	#var color_array = [Color.RED]
-
 	var old_entity_1 = backend.create_entity("Entity 1", category_d)
-	#old_entity_1.get_array("typed_array").append_array(color_array)
 
 	var data = backend.save_data()
 	assert_that(data._categories).is_not_null()
@@ -261,53 +257,14 @@ func test_save_and_load_data() -> void:
 
 	backend.load_data(data)
 
-	print("Loaded data")
-
 	var new_entity_1 = backend.get_entity(old_entity_1.get_entity_id())
 	
 	var old_color_array = old_entity_1.get_array("typed_array")
 	var new_color_array = new_entity_1.get_array("typed_array")
 
-	print("Got Array")
-	print(old_color_array)
-	print(new_color_array)
-	
-	print(typeof(old_color_array[0]))
-	print(typeof(new_color_array[0]))
-
-	# print("Entities")
-	# print(old_entities)
-	# print(backend._entities)
-
-	# print(old_entities["9"])
-
-	# var class_instance = old_entities["9"]
-	# var output = {}
-	# var methods = []
-	# for method in class_instance.get_method_list():
-	# 	methods.append(method.name)
-
-	# output["METHODS"] = methods
-
-	# var properties = []
-	# for prop in class_instance.get_property_list():
-	# 	if prop.type == 3:
-	# 		properties.append(prop.name)
-	# output["PROPERTIES"] = properties
-	# print(output)
-
-	#print(backend._entities["9"])
-
-	# Making this call after getting the array from either of the entities (old/new) will throw the error ERROR: Max recursion reached
-   	# at: write (core/variant/variant_parser.cpp:1942)
-	#assert_that(old_entities).is_equal(backend._entities)
-	
-	print("Categories")
-	print(old_categories)
-	print(backend._categories)
-
-	#assert_that(old_categories).is_equal(backend._categories)
-	#assert_that(new_color_array[0]).is_equal(color_array[0])
+	assert_that(new_color_array[0]).is_equal(old_color_array[0])
+	assert_that(old_entities).is_equal(backend._entities)
+	assert_that(old_categories).is_equal(backend._categories)
 
 
 func test_inherit_correct_properties() -> void:

--- a/test/backend/entity_backend_test.gd
+++ b/test/backend/entity_backend_test.gd
@@ -244,17 +244,70 @@ func test_save_and_load_data() -> void:
 	var category_a = backend.create_category("a")
 	var category_b = backend.create_category("b")
 	var category_c = backend.create_category("c", category_b)
+	var category_d = backend.create_category("d")
 	backend.create_entity("a", category_a)
 	backend.create_entity("b", category_b)
 	backend.create_property(category_c, "property1", "string", "Hello World")
+	backend.create_property(category_d, "typed_array", "array", [Color.RED])
+
+	#var color_array = [Color.RED]
+
+	var old_entity_1 = backend.create_entity("Entity 1", category_d)
+	#old_entity_1.get_array("typed_array").append_array(color_array)
+
 	var data = backend.save_data()
 	assert_that(data._categories).is_not_null()
 	assert_that(data._entities).is_not_null()
-	
+
 	backend.load_data(data)
+
+	print("Loaded data")
+
+	var new_entity_1 = backend.get_entity(old_entity_1.get_entity_id())
 	
-	assert_that(old_entities).is_equal(backend._entities)
-	assert_that(old_categories).is_equal(backend._categories)
+	var old_color_array = old_entity_1.get_array("typed_array")
+	var new_color_array = new_entity_1.get_array("typed_array")
+
+	print("Got Array")
+	print(old_color_array)
+	print(new_color_array)
+	
+	print(typeof(old_color_array[0]))
+	print(typeof(new_color_array[0]))
+
+	# print("Entities")
+	# print(old_entities)
+	# print(backend._entities)
+
+	# print(old_entities["9"])
+
+	# var class_instance = old_entities["9"]
+	# var output = {}
+	# var methods = []
+	# for method in class_instance.get_method_list():
+	# 	methods.append(method.name)
+
+	# output["METHODS"] = methods
+
+	# var properties = []
+	# for prop in class_instance.get_property_list():
+	# 	if prop.type == 3:
+	# 		properties.append(prop.name)
+	# output["PROPERTIES"] = properties
+	# print(output)
+
+	#print(backend._entities["9"])
+
+	# Making this call after getting the array from either of the entities (old/new) will throw the error ERROR: Max recursion reached
+   	# at: write (core/variant/variant_parser.cpp:1942)
+	#assert_that(old_entities).is_equal(backend._entities)
+	
+	print("Categories")
+	print(old_categories)
+	print(backend._categories)
+
+	#assert_that(old_categories).is_equal(backend._categories)
+	#assert_that(new_color_array[0]).is_equal(color_array[0])
 
 
 func test_inherit_correct_properties() -> void:

--- a/test/model/property_test.gd
+++ b/test/model/property_test.gd
@@ -146,6 +146,18 @@ func test_array_property_wrong_type() -> void:
 	new_property.load_data(property.save_data())
 	assert_that(new_property.get_default_value()).is_equal("")
 
+func test_array_property_custom_parsers() -> void:
+	var array_type = load("res://addons/pandora/model/types/array.gd")
+	var category = Pandora.create_category("Test Category")
+	var property = Pandora.create_property(category, "property", "array")
+	property.set_setting_override(array_type.SETTING_ARRAY_TYPE, "color")
+	var entity = Pandora.create_entity("entity", category)
+	var entity_property = entity.get_entity_property("property")
+	entity_property.set_default_value([Color.WHITE])
+	entity.load_data(entity.save_data())
+	assert_that(entity.get_array("property")[0]).is_equal(Color.WHITE)
+	assert_that(typeof(entity.get_array("property")[0])).is_not_equal(TYPE_STRING)
+
 func test_vector2_property() -> void:
 	var vector = Vector2.ONE
 	var property = PandoraProperty.new("123", "property", "vector2")


### PR DESCRIPTION
An alternative approach to https://github.com/bitbrain/pandora/pull/162

The array serialization/deserialization is working in the test for Color.

*Outstanding questions*
Should a reference deserialize into the entity itself or a reference type?

ie. What would make more sense?

get_array("Equipment") return Array[PandoraReference] and you manually .map(func(r): return r.get_entity())
or we do that step ourselves in the deserialization

get_array("Equipment") return Array[PandoraEntity] which feels a bit more logical to hide the reference.

Old save/load cycle

```gdscript
var old_color_array = old_entity_1.get_array("typed_array")
var new_color_array = new_entity_1.get_array("typed_array")

print("Got Array")
print(old_color_array)
print(new_color_array)

print(typeof(old_color_array[0]))
print(typeof(new_color_array[0]))

[(1, 0, 0, 1)]
["ff0000ff"]
20
4
```

New array code.

```gdscript
var old_color_array = old_entity_1.get_array("typed_array")
var new_color_array = new_entity_1.get_array("typed_array")

print("Got Array")
print(old_color_array)
print(new_color_array)

print(typeof(old_color_array[0]))
print(typeof(new_color_array[0]))

[(1, 0, 0, 1)]
[(1, 0, 0, 1)]
20
20
```

However, I am struggling a bit with the test because the minute I call either of

```
var old_color_array = old_entity_1.get_array("typed_array")
var new_color_array = new_entity_1.get_array("typed_array")
```

something inside of the ._entities dictionary is loading a recursive reference because running

```
# Making this call after getting the array from either of the entities (old/new) will throw the error ERROR: Max recursion reached at: write (core/variant/variant_parser.cpp:1942)
assert_that(old_entities).is_equal(backend._entities)
```

Throws millions of exceptions (forever).
I've tried to introspect the objects in the dictionary but I can't for the life of me work out what reference if circular and what property on PandoraEntity is being introspected. Throwing this up to get feedback on the approach and to see if anyone can help debug why I can't do an is_equal comparison on them.

My hypothesis is that the value loaded into .property_map has a reference to itself but it's hard to print the stack and I can't breakpoint since there's no error, just a bunch of warnings in a loop.