### PR TITLE
Prevent button's icons from expanding the inspector button

### DIFF
--- a/addons/pandora/ui/editor/inspector/entity_instance_browser_property.gd
+++ b/addons/pandora/ui/editor/inspector/entity_instance_browser_property.gd
@@ -14,11 +14,16 @@ func _init(class_data: Dictionary) -> void:
 
 	var id_counter = 0
 	var all_entities = _find_all_entities(class_data["path"])
+	var editor_plugin: EditorPlugin = Engine.get_meta("PandoraEditorPlugin", null)
+	# Prevent button from expanding to selected icon size.
+	property_control.set_expand_icon(true)
 
 	for entity in all_entities:
 		property_control.get_popup().add_icon_item(
 			load(entity.get_icon_path()), entity.get_entity_name(), id_counter
 		)
+		if editor_plugin:
+			property_control.get_popup().set_item_icon_max_width(id_counter, editor_plugin.get_editor_interface().get_editor_scale() * 16)
 		# Godot 4.1+
 		if property_control.get_popup().has_method("set_item_icon_modulate"):
 			property_control.get_popup().set_item_icon_modulate(id_counter, entity.get_icon_color())


### PR DESCRIPTION
## Description

This prevents the inspector entity browser button from be expanded by icons bigger than 16px.

## Screenshots

Before
![](https://github.com/bitbrain/pandora/assets/61943525/635fa707-36b3-49f3-b5fe-ff1131481a0e)
![](https://github.com/bitbrain/pandora/assets/61943525/b921c823-71d7-4926-b7bc-0cd1f5950c20)
After
![](https://github.com/bitbrain/pandora/assets/61943525/e40d8b86-59db-41e7-b4cb-5deeff943df6)
