### PR TITLE
Don't add the same entity more than once when filling entity browser button

### DIFF
--- a/addons/pandora/ui/editor/inspector/entity_instance_browser_property.gd
+++ b/addons/pandora/ui/editor/inspector/entity_instance_browser_property.gd
@@ -63,6 +63,7 @@ func _find_all_entities(script_path: String) -> Array[PandoraEntity]:
 		if category._script_path == script_path:
 			var entities = Pandora.get_all_entities(category)
 			for entity in entities:
+				if entity in all_entities: continue
 				all_entities.append(entity)
 	if all_entities.is_empty():
 		all_entities = Pandora.get_all_entities()


### PR DESCRIPTION
## Description

Prevent duplicate entities when browsing an exported pandora entity.
This happens when an entity is in a child category that has the same script as the parent, and then using the parent script as an export var.

Example to reproduce:
```gdscript
# item.gd
@tool
extends PandoraEntity class_name Item

# Pandora Tree

[ ] is a Category
* is an Entity 

[ ] ITEM (item.gd)
 |___ [ ]Potions (item.gd)
        |____ * Generic Potion


# Your Node
...
@export var item: Item
```

## Screenshots
Before
![](https://github.com/bitbrain/pandora/assets/61943525/f82e8e59-1bdb-4ae8-aff9-982d3ea2206e)

After
![](https://github.com/bitbrain/pandora/assets/61943525/6057cd39-d8e4-41b9-9753-e8390b70f32f)
