### PR TITLE
Clear entity browser dropdown selection after resetting property

### DIFF
--- a/addons/pandora/ui/editor/inspector/entity_instance_browser_property.gd
+++ b/addons/pandora/ui/editor/inspector/entity_instance_browser_property.gd
@@ -51,6 +51,7 @@ func _update_property() -> void:
 func _update_deferred() -> void:
 	var current_entity = get_edited_object()[get_edited_property()] as PandoraEntity
 	if current_entity == null:
+		property_control.select(-1)
 		return
 	for id in ids_to_entities.keys():
 		if ids_to_entities[id].get_entity_id() == current_entity.get_entity_id():


### PR DESCRIPTION
## Description

This fixes an issue where the dropdown menu selection won't get cleared after resetting the property.

## Addressed issues

Fixes #144 

## Screenshots

Dropdown after reset:
![](https://github.com/bitbrain/pandora/assets/61943525/7a58738d-ff20-4f68-b9bc-854d42a8cd46)
