### PR TITLE
fix: skip object != null check in entity instance inspector

### DIFF
--- a/addons/pandora/ui/editor/inspector/entity_instance_inspector.gd
+++ b/addons/pandora/ui/editor/inspector/entity_instance_inspector.gd
@@ -17,7 +17,7 @@ func _parse_property(object, type, name, hint_type, hint_string, usage_flags, wi
 	if _global_class_cache.is_empty():
 		for global_class in ProjectSettings.get_global_class_list():
 			_global_class_cache[global_class["class"]] = global_class
-	if object != null && type == TYPE_OBJECT:
+	if type == TYPE_OBJECT:
 		var test_instance = ClassDB
 		if _is_pandora_entity(hint_string):
 			var inspector_property := BrowserProperty.new(_global_class_cache[hint_string])


### PR DESCRIPTION
It seems that when an array is exported, the `object` comes through as 'null', but allowing the code to continue here seems to work fine. The above `can_handle` impl already checks to be sure the pandora entities are not null.

Fixes #131.

Much thanks to @shomykohai for researching the related engine code: https://github.com/godotengine/godot/blob/6a13fdcae3662975c101213d47a1eb3a7db63cb3/editor/editor_inspector.cpp#L2600-L2603