### PR TITLE
Fix compiled script not being assigned to entities

### DIFF
--- a/addons/pandora/util/script_util.gd
+++ b/addons/pandora/util/script_util.gd
@@ -39,7 +39,7 @@ static func create_entity_from_script(
 
 static func _get_entity_class(path: String) -> GDScript:
 	var EntityClass = load(path)
-	if EntityClass == null or not EntityClass.has_source_code():
+	if EntityClass == null:
 		push_warning("Unable to find " + path + " - defaulting to PandoraEntity instead.")
 		EntityClass = PandoraEntityScript
 	return EntityClass


### PR DESCRIPTION
Fixes compiled script not being assigned to pandora entities in Godot 4.3 if the [script is compiled](https://godotengine.org/article/dev-snapshot-godot-4-3-beta-1/#gdscript).

Note: Haven't tried it on Godot 4.2

## Addressed issues

This fixes #187.