### PR TITLE
Fix resource references not being loaded on exported builds (Godot 4.3)

### DIFF
--- a/addons/pandora/model/entity.gd
+++ b/addons/pandora/model/entity.gd
@@ -526,7 +526,7 @@ func get_resource(property_name: String) -> Resource:
 	if not has_entity_property(property_name):
 		push_warning("unknown resource property %s on entity %s" % [property_name, get_entity_id()])
 		return null
-	# HACK: For some reason in Godot 4.3, resource properties are
+	# FIXME: For some reason in Godot 4.3, resource properties are
 	# are considered Strings on exported builds with GDScript mode set to binary tokens.
 	# Here, instead of returning the default value and casting it to Resource,
 	# we check its type and we handle it accordingly.

--- a/addons/pandora/model/entity.gd
+++ b/addons/pandora/model/entity.gd
@@ -531,7 +531,7 @@ func get_resource(property_name: String) -> Resource:
 	# Here, instead of returning the default value and casting it to Resource,
 	# we check its type and we handle it accordingly.
 	var default_value = get_entity_property(property_name).get_default_value()
-	if default_value is not Resource:
+	if not default_value is Resource:
 		return load(default_value)
 	return default_value
 

--- a/addons/pandora/model/entity.gd
+++ b/addons/pandora/model/entity.gd
@@ -526,7 +526,14 @@ func get_resource(property_name: String) -> Resource:
 	if not has_entity_property(property_name):
 		push_warning("unknown resource property %s on entity %s" % [property_name, get_entity_id()])
 		return null
-	return get_entity_property(property_name).get_default_value() as Resource
+	# HACK: For some reason in Godot 4.3, resource properties are
+	# are considered Strings on exported builds with GDScript mode set to binary tokens.
+	# Here, instead of returning the default value and casting it to Resource,
+	# we check its type and we handle it accordingly.
+	var default_value = get_entity_property(property_name).get_default_value()
+	if default_value is not Resource:
+		return load(default_value)
+	return default_value
 
 
 func get_array(property_name: String) -> Array:


### PR DESCRIPTION
## Description

On exported builds, it is not guaranteed that the `get_default_value` returns a Resource, even if we cast it.
In fact, in the editor they are treated as Resources, but on exported builds they are Strings.
This prevents casting a String as a Resource by calling `load()` if default_value is not a Resource.

Edit: The issue seem to be related to the same one as #187, the generated GDScript bytecode on exported builds.
## Screenshots

Printing out `default_value` before this PR:
EDITOR:
![Editor output](https://github.com/bitbrain/pandora/assets/61943525/e839e713-8c16-466e-b15f-7dc9c475043f)
EXPORTED BUILD:
![Exported build output](https://github.com/bitbrain/pandora/assets/61943525/e023f3c4-12b2-4325-9acb-7b70e0c29b76)
