### PR TITLE
Fix Pandora error in array type

### DIFF
--- a/addons/pandora/model/types/array.gd
+++ b/addons/pandora/model/types/array.gd
@@ -36,7 +36,7 @@ func parse_value(variant: Variant, settings: Dictionary = {}) -> Variant:
 		for i in range(dict.size()):
 			var value = dict[str(i)]
 			if not settings.is_empty():
-				if settings[SETTING_ARRAY_TYPE] == "reference":
+				if settings[SETTING_ARRAY_TYPE] == "reference" and "_entity_id" in value:
 					value = PandoraReference.new(value["_entity_id"], value["_type"]).get_entity()
 				if settings[SETTING_ARRAY_TYPE] == "resource":
 					value = load(value)


### PR DESCRIPTION
It may happen that for existing projects `value` was not initialized with `_entity_id` - in that case let us skip it.