### PR TITLE
include the @tool annotation in custom-scripts.md

### DIFF
--- a/docs/mastery/custom-scripts.md
+++ b/docs/mastery/custom-scripts.md
@@ -8,6 +8,7 @@ var texture = pickaxe.get_resource("Item Texture") as Texture2D
 ```
 A better solution is to define a custom `Item` type like so (it **must** extend `PandoraEntity`):
 ```gdscript
+@tool
 class_name Item extends PandoraEntity
 
 


### PR DESCRIPTION

## Description

I followed the custom script example and received the warning `core/variant/variant_utility.cpp:1112 - Unable to find <script name> - defaulting to PandoraEntity instead.`  
Fortunately I had read https://bitbra.in/pandora/#/api/access so I remembered to add `@tool`, hopefully including it here as well will help others.

## Addressed issues

## Screenshots

Before
![image](https://github.com/user-attachments/assets/72e1d062-5692-4983-b475-5d12dd9df86b)

After
![image](https://github.com/user-attachments/assets/413ad8a7-2f33-4cc7-957a-17009ff9f300)
😄 