### PR TITLE
Allow defining a custom path for `data.pandora` and `pandora` definitions dir

### DIFF
--- a/addons/pandora/api.gd
+++ b/addons/pandora/api.gd
@@ -24,7 +24,9 @@ var _backend_load_state: PandoraEntityBackend.LoadState = PandoraEntityBackend.L
 
 
 func _enter_tree() -> void:
-	self._storage = PandoraJsonDataStorage.new("res://")
+	var data_path := PandoraSettings.get_data_path()
+
+	self._storage = PandoraJsonDataStorage.new(data_path.get_base_dir())
 	self._context_manager = PandoraContextManager.new()
 	self._id_generator = PandoraIDGenerator.new()
 	self._entity_backend = PandoraEntityBackend.new(_id_generator)
@@ -179,7 +181,7 @@ func calculate_import_data(path: String) -> int:
 		else:
 			(
 				import_calculation_ended
-				. emit(
+				.emit(
 					{
 						"total_categories": imported_data["_entity_data"]["_categories"].size(),
 						"total_entities": imported_data["_entity_data"]["_entities"].size(),

--- a/addons/pandora/plugin.gd
+++ b/addons/pandora/plugin.gd
@@ -56,7 +56,7 @@ func _exit_tree() -> void:
 	remove_autoload_singleton("Pandora")
 
 
-func _make_visible(visible:bool) -> void:
+func _make_visible(visible: bool) -> void:
 	if Engine.is_editor_hint() and is_instance_valid(editor_view):
 		editor_view.visible = visible
 
@@ -75,12 +75,12 @@ func _get_plugin_icon() -> Texture2D:
 class PandoraExportPlugin extends EditorExportPlugin:
 	# Override the _export_begin method to add the data.pandora file during export
 	func _export_begin(features: PackedStringArray, is_debug: bool, path: String, flags: int):
-		var pandora_path = "res://data.pandora"
+		var pandora_path = PandoraSettings.get_data_path()
 		var file = FileAccess.open(pandora_path, FileAccess.READ)
 		if not file:
-			printerr("Unable to export Pandora data: ",  FileAccess.get_open_error())
+			printerr("Unable to export Pandora data: ", FileAccess.get_open_error())
 			return
-		var data:PackedByteArray = file.get_buffer(file.get_length())
+		var data: PackedByteArray = file.get_buffer(file.get_length())
 		if not is_debug:
 			var text = file.get_as_text()
 			data = Compression.compress(text)

--- a/addons/pandora/settings/pandora_settings.gd
+++ b/addons/pandora/settings/pandora_settings.gd
@@ -3,8 +3,8 @@ class_name PandoraSettings
 extends RefCounted
 
 enum IDType {
-	SEQUENTIAL,
-	NANOID,
+    SEQUENTIAL,
+    NANOID,
 }
 
 const CATEGORY_MAIN: StringName = "pandora"
@@ -14,43 +14,63 @@ const SETTING_ID_TYPE: StringName = CATEGORY_CONFIG + "/id_type"
 
 const DEFAULT_ID_TYPE: IDType = IDType.SEQUENTIAL
 
+const SETTING_PANDORA_DATA_PATH: StringName = CATEGORY_CONFIG + "/data_path"
+const DEFAULT_PANDORA_DATA_PATH: StringName = "res://data.pandora"
 
 static func initialize() -> void:
-	init_setting(
-		SETTING_ID_TYPE,
-		IDType.keys()[DEFAULT_ID_TYPE],
-		TYPE_STRING,
-		PROPERTY_HINT_ENUM,
-		"%s,%s" % IDType.keys()
-	)
+    init_setting(
+        SETTING_ID_TYPE,
+        IDType.keys()[DEFAULT_ID_TYPE],
+        TYPE_STRING,
+        PROPERTY_HINT_ENUM,
+        "%s,%s" % IDType.keys()
+    )
+
+    init_setting(
+        SETTING_PANDORA_DATA_PATH,
+        DEFAULT_PANDORA_DATA_PATH,
+        TYPE_STRING,
+        PROPERTY_HINT_FILE,
+    )
 
 
 static func init_setting(
-	name: String,
-	default: Variant,
-	type := typeof(default),
-	hint := PROPERTY_HINT_NONE,
-	hint_string := ""
+    name: String,
+    default: Variant,
+    type := typeof(default),
+    hint := PROPERTY_HINT_NONE,
+    hint_string := ""
 ) -> void:
-	if not ProjectSettings.has_setting(name):
-		ProjectSettings.set_setting(name, default)
+    if not ProjectSettings.has_setting(name):
+        ProjectSettings.set_setting(name, default)
 
-	ProjectSettings.set_initial_value(name, default)
+    ProjectSettings.set_initial_value(name, default)
 
-	var info = {
-		"name": name,
-		"type": type,
-		"hint": hint,
-		"hint_string": hint_string,
-	}
-	ProjectSettings.add_property_info(info)
+    var info = {
+        "name": name,
+        "type": type,
+        "hint": hint,
+        "hint_string": hint_string,
+    }
+    ProjectSettings.add_property_info(info)
 
 
 static func get_id_type() -> IDType:
-	var default: StringName = IDType.keys()[DEFAULT_ID_TYPE]
-	var key := ProjectSettings.get_setting(SETTING_ID_TYPE, default)
-	return IDType[key]
+    var default: StringName = IDType.keys()[DEFAULT_ID_TYPE]
+    var key := ProjectSettings.get_setting(SETTING_ID_TYPE, default)
+    return IDType[key]
 
 
 static func set_id_type(id_type: IDType) -> void:
-	ProjectSettings.set_setting(SETTING_ID_TYPE, IDType.keys()[id_type])
+    ProjectSettings.set_setting(SETTING_ID_TYPE, IDType.keys()[id_type])
+
+
+static func get_data_path() -> StringName:
+    return ProjectSettings.get_setting(
+        SETTING_PANDORA_DATA_PATH,
+        DEFAULT_PANDORA_DATA_PATH
+    )
+
+
+static func set_data_path(path: StringName) -> void:
+    ProjectSettings.set_setting(SETTING_PANDORA_DATA_PATH, path)

--- a/addons/pandora/settings/pandora_settings.gd
+++ b/addons/pandora/settings/pandora_settings.gd
@@ -17,6 +17,10 @@ const DEFAULT_ID_TYPE: IDType = IDType.SEQUENTIAL
 const SETTING_PANDORA_DATA_PATH: StringName = CATEGORY_CONFIG + "/data_path"
 const DEFAULT_PANDORA_DATA_PATH: StringName = "res://data.pandora"
 
+const SETTINGS_PANDORA_DEFINITIONS_DIR: StringName = CATEGORY_CONFIG + "/definitions_dir"
+const DEFAULT_PANDORA_DEFINITIONS_DIR: StringName = "res://pandora/"
+
+
 static func initialize() -> void:
     init_setting(
         SETTING_ID_TYPE,
@@ -31,6 +35,13 @@ static func initialize() -> void:
         DEFAULT_PANDORA_DATA_PATH,
         TYPE_STRING,
         PROPERTY_HINT_FILE,
+    )
+
+    init_setting(
+        SETTINGS_PANDORA_DEFINITIONS_DIR,
+        DEFAULT_PANDORA_DEFINITIONS_DIR,
+        TYPE_STRING,
+        PROPERTY_HINT_DIR
     )
 
 
@@ -74,3 +85,14 @@ static func get_data_path() -> StringName:
 
 static func set_data_path(path: StringName) -> void:
     ProjectSettings.set_setting(SETTING_PANDORA_DATA_PATH, path)
+
+
+static func get_definitions_dir() -> StringName:
+    return ProjectSettings.get_setting(
+        SETTINGS_PANDORA_DEFINITIONS_DIR,
+        DEFAULT_PANDORA_DEFINITIONS_DIR
+    )
+
+
+static func set_definitions_dir(path: StringName) -> void:
+    ProjectSettings.set_setting(SETTINGS_PANDORA_DEFINITIONS_DIR, path)

--- a/addons/pandora/storage/json/json_data_storage.gd
+++ b/addons/pandora/storage/json/json_data_storage.gd
@@ -100,7 +100,13 @@ func _get_directory_path(context_id: String) -> String:
 
 
 func _get_file_path(context_id: String) -> String:
-	return "%s/data.pandora" % [_get_directory_path(context_id)]
+	# Allow to override the file name in the settings based
+	# on whether the user has set a custom data path
+	var file_name := "data.pandora"
+	if PandoraSettings.get_data_path().get_file() != "data.pandora":
+		file_name = PandoraSettings.get_data_path().get_file()
+
+	return "%s/%s" % [_get_directory_path(context_id), file_name]
 
 
 func _should_use_compression() -> bool:

--- a/addons/pandora/util/category_id_file_generator.gd
+++ b/addons/pandora/util/category_id_file_generator.gd
@@ -47,19 +47,20 @@ static func _process_sub_category_tuples(
 
 			# Add current category to the local list if it's a leaf or has children
 			if not subcategory_tuples.has(new_key) or subcategory_tuples[new_key].size() == 0:
-				subcategory_tuples.erase(new_key)  # Remove if empty
+				subcategory_tuples.erase(new_key) # Remove if empty
 			local_subcategories.append(category_tuple)
 
 	if local_subcategories.size() > 0:
 		subcategory_tuples[parent_category] = local_subcategories
 
 
-
 static func generate_category_id_file(
 	root_category_tuples: Array[CategoryTuple], subcategory_tuples: Dictionary) -> void:
-	var file_path = "res://pandora/categories.gd"
-	if not DirAccess.dir_exists_absolute("res://pandora"):
-		DirAccess.make_dir_absolute("res://pandora")
+	var definitions_dir := PandoraSettings.get_definitions_dir()
+	var file_path = "%s/categories.gd" % definitions_dir
+	file_path.replace("//", "/") # Ensure correct path format
+	if not DirAccess.dir_exists_absolute(definitions_dir):
+		DirAccess.make_dir_absolute(definitions_dir)
 
 	var file_access = FileAccess.open(file_path, FileAccess.WRITE)
 	file_access.store_line("# Do not modify! Auto-generated file.")

--- a/addons/pandora/util/entity_id_file_generator.gd
+++ b/addons/pandora/util/entity_id_file_generator.gd
@@ -25,7 +25,7 @@ static func generate_class_to_entity_map(root_categories: Array[PandoraCategory]
 static func generate_entity_id_file(entity_class_name: String, entities: Array[PandoraEntity]) -> Array[String]:
 	if entities.is_empty():
 		return []
-	var lines:Array[String] = ["# Do not modify! Auto-generated file.", "class_name " + entity_class_name + "\n\n"]
+	var lines: Array[String] = ["# Do not modify! Auto-generated file.", "class_name " + entity_class_name + "\n\n"]
 	var name_usages = {}
 	for entity in entities:
 		var entity_name = entity.get_entity_name()
@@ -40,7 +40,7 @@ static func generate_entity_id_file(entity_class_name: String, entities: Array[P
 static func _process_category_for_id_files(category: PandoraCategory, class_to_entity_map: Dictionary) -> void:
 	var classname = category.get_id_generation_class()
 	if not class_to_entity_map.has(classname):
-		var empty:Array[PandoraEntity] = []
+		var empty: Array[PandoraEntity] = []
 		class_to_entity_map[classname] = empty
 
 	if category.is_generate_ids():
@@ -66,9 +66,13 @@ static func _entity_exists_in_map(entity_list: Array[PandoraEntity], entity: Pan
 	return false
 
 static func _write_to_file(entity_class_name: String, lines: Array[String]) -> void:
-	var file_path = "res://pandora/" + entity_class_name.to_snake_case() + ".gd"
-	if not DirAccess.dir_exists_absolute("res://pandora"):
-		DirAccess.make_dir_absolute("res://pandora")
+	var definitions_dir := PandoraSettings.get_definitions_dir()
+	if not definitions_dir.ends_with("/"):
+		definitions_dir += "/"
+
+	var file_path = definitions_dir + entity_class_name.to_snake_case() + ".gd"
+	if not DirAccess.dir_exists_absolute(definitions_dir):
+		DirAccess.make_dir_absolute(definitions_dir)
 
 	var file = FileAccess.open(file_path, FileAccess.WRITE)
 	if FileAccess.get_open_error() == OK:

--- a/test/settings/pandora_settings_test.gd
+++ b/test/settings/pandora_settings_test.gd
@@ -68,6 +68,8 @@ func test_set_data_path() -> void:
 		SETTING_PANDORA_DATA_PATH, "res://data.pandora",
 		TYPE_STRING, PROPERTY_HINT_FILE, "*.pandora"
 	)
+	
+	Pandora.set_context_id("")
 	var new_path: String = "res://" + TEST_DIR + "/" + "collection.pandora"
 	PandoraSettings.set_data_path(new_path)
 	assert_str(PandoraSettings.get_data_path()).is_equal(new_path)
@@ -76,7 +78,6 @@ func test_set_data_path() -> void:
 	Pandora._storage = PandoraJsonDataStorage.new(new_path.get_base_dir())
 	# Resave the data to ensure it uses the new path
 	Pandora.save_data()
-
 	# Unload and reload the data to ensure it reflects the new path
 	Pandora._clear()
 	Pandora.load_data()

--- a/test/settings/pandora_settings_test.gd
+++ b/test/settings/pandora_settings_test.gd
@@ -7,11 +7,12 @@ extends GdUnitTestSuite
 
 # TestSuite generated from
 const __source = 'res://addons/pandora/settings/pandora_settings.gd'
-
+const TEST_DIR = "testdata"
 
 const IDType := PandoraSettings.IDType
 
 const SETTING_ID_TYPE := PandoraSettings.SETTING_ID_TYPE
+const SETTING_PANDORA_DATA_PATH := PandoraSettings.SETTING_PANDORA_DATA_PATH
 
 
 func test_initialize() -> void:
@@ -48,3 +49,49 @@ func test_set_id_type() -> void:
 			PROPERTY_HINT_ENUM, "%s,%s" % IDType.keys())
 	PandoraSettings.set_id_type(IDType.NANOID)
 	assert_int(PandoraSettings.get_id_type()).is_equal(IDType.NANOID)
+
+
+func test_get_data_path() -> void:
+	ProjectSettings.clear(SETTING_PANDORA_DATA_PATH)
+	PandoraSettings.init_setting(
+		SETTING_PANDORA_DATA_PATH, "res://data.pandora",
+		TYPE_STRING, PROPERTY_HINT_FILE, "*.pandora"
+	)
+	var expected: String = ProjectSettings.get_setting(SETTING_PANDORA_DATA_PATH)
+	var actual := PandoraSettings.get_data_path()
+	assert_str(actual).is_equal(expected)
+
+
+func test_set_data_path() -> void:
+	ProjectSettings.clear(SETTING_PANDORA_DATA_PATH)
+	PandoraSettings.init_setting(
+		SETTING_PANDORA_DATA_PATH, "res://data.pandora",
+		TYPE_STRING, PROPERTY_HINT_FILE, "*.pandora"
+	)
+	var new_path: String = "res://" + TEST_DIR + "/" + "collection.pandora"
+	PandoraSettings.set_data_path(new_path)
+	assert_str(PandoraSettings.get_data_path()).is_equal(new_path)
+
+	# Reinitialize the data storage with the new path
+	Pandora._storage = PandoraJsonDataStorage.new(new_path.get_base_dir())
+	# Resave the data to ensure it uses the new path
+	Pandora.save_data()
+
+	# Unload and reload the data to ensure it reflects the new path
+	Pandora._clear()
+	Pandora.load_data()
+
+	assert_array(Pandora.get_all_entities()).is_not_empty()
+
+	assert_file(new_path).exists()
+
+	# Clean up
+	DirAccess.remove_absolute(new_path)
+
+	PandoraSettings.set_data_path("res://data.pandora")
+	assert_str(PandoraSettings.get_data_path()).is_equal("res://data.pandora")
+	
+	Pandora._storage = PandoraJsonDataStorage.new(PandoraSettings.get_data_path().get_base_dir())
+
+	Pandora._clear()
+	Pandora.load_data()


### PR DESCRIPTION
## Description

This PR allows to override the default path for `data.pandora` (in the default context_id), so that it is possible to move the file anywhere else (i.e. inside `res://content/data.pandora`), as well as allowing to change where the automatically generated definitions are stored (the `res:/pandora/` directory)