### PR TITLE
Fix crash when clicking on underlined property key

### DIFF
--- a/addons/pandora/ui/editor/property_editor/property_editor.gd
+++ b/addons/pandora/ui/editor/property_editor/property_editor.gd
@@ -21,7 +21,7 @@ var current_entity: PandoraEntity
 
 
 func _ready() -> void:
-	property_bar.property_added.connect(_add_property)
+	property_bar.property_added.connect(_add_property.bind(true))
 	set_entity(null)
 
 
@@ -58,7 +58,9 @@ func set_entity(entity: PandoraEntity) -> void:
 			_add_property_control(control, property)
 
 
-func _add_property(scene: PackedScene) -> void:
+# The focus parameter is optional, and only used to ask the editor to also focus to the
+# specified property
+func _add_property(scene: PackedScene, focus: bool = false) -> void:
 	if not current_entity is PandoraCategory:
 		print("Cannot add custom properties to non-categories!")
 		return
@@ -69,10 +71,10 @@ func _add_property(scene: PackedScene) -> void:
 		control.type
 	)
 	if property != null:
-		_add_property_control(control, property)
+		_add_property_control(control, property, focus)
 
 
-func _add_property_control(control: PandoraPropertyControl, property: PandoraProperty) -> void:
+func _add_property_control(control: PandoraPropertyControl, property: PandoraProperty, focus: bool = false) -> void:
 	var control_kvp = PropertyControlKvp.instantiate()
 	control.init(property)
 	control_kvp.init(property, control, Pandora._entity_backend)
@@ -84,11 +86,12 @@ func _add_property_control(control: PandoraPropertyControl, property: PandoraPro
 	property_list.add_child(control_kvp)
 	control_kvp.property_key_edit.grab_focus()
 	control_kvp.original_property_selected.connect(property_settings_container.set_property)
-	await get_tree().process_frame
 	# First scroll to the control node and then apply an offset.
 	# It's important to wait a frame before scrolling as for the documentation.
-	scroll_container.ensure_control_visible(control_kvp)
-	scroll_container.scroll_vertical = scroll_container.scroll_vertical + 100
+	if focus:
+		await get_tree().process_frame
+		scroll_container.ensure_control_visible(control_kvp)
+		scroll_container.scroll_vertical = scroll_container.scroll_vertical + 100
 
 
 func _generate_property_name(type: String, entity: PandoraEntity) -> String:


### PR DESCRIPTION
## Description

Normally, when clicking on a property key of an entity, Pandora will try to redirect to the definition of that property prompting to edit the key.

#202 introduced a regression, because Godot will try to focus the new properties and change screen at the same time, resulting in a call to a freed instance.

This PR ensures the new property is getting focused only when adding it from the property bar (as it should have been to begin with). 

## Addressed issues
- closes #226 