### PR TITLE
Added a is_actual_type to the type to differentiate type identificatio…

### DIFF
--- a/addons/pandora/model/type.gd
+++ b/addons/pandora/model/type.gd
@@ -58,6 +58,8 @@ func get_type_icon_path() -> String:
 func is_valid(variant: Variant) -> bool:
 	return false
 
+func is_actual_type(variant: Variant) -> bool:
+	return false
 
 func allow_nesting() -> bool:
 	return true

--- a/addons/pandora/model/types/array.gd
+++ b/addons/pandora/model/types/array.gd
@@ -20,6 +20,9 @@ func _init() -> void:
 func is_valid(variant: Variant) -> bool:
 	return variant is Array
 
+func is_actual_type(variant: Variant) -> bool:
+	return variant is Array
+
 
 func get_merged_settings(property: PandoraProperty) -> Dictionary:
 	var merged_settings: Dictionary = _settings.duplicate()
@@ -95,7 +98,7 @@ func write_value(variant: Variant) -> Variant:
 				value = value_type.write_value(value)
 			else:
 				for type in types:
-					if type.is_valid(value):
+					if type.is_actual_type(value):
 						value_type = type
 						value = type.write_value(value)
 						break

--- a/addons/pandora/model/types/bool.gd
+++ b/addons/pandora/model/types/bool.gd
@@ -11,3 +11,6 @@ func _init() -> void:
 
 func is_valid(variant: Variant) -> bool:
 	return variant is bool
+
+func is_actual_type(variant: Variant) -> bool:
+	return variant is bool

--- a/addons/pandora/model/types/color.gd
+++ b/addons/pandora/model/types/color.gd
@@ -22,3 +22,6 @@ func write_value(variant: Variant) -> Variant:
 
 func is_valid(variant: Variant) -> bool:
 	return variant is Color or variant is String
+
+func is_actual_type(variant: Variant) -> bool:
+	return variant is Color

--- a/addons/pandora/model/types/float.gd
+++ b/addons/pandora/model/types/float.gd
@@ -19,3 +19,6 @@ func _init() -> void:
 
 func is_valid(variant: Variant) -> bool:
 	return variant is float
+
+func is_actual_type(variant: Variant) -> bool:
+	return variant is float

--- a/addons/pandora/model/types/int.gd
+++ b/addons/pandora/model/types/int.gd
@@ -23,3 +23,6 @@ func parse_value(variant: Variant, settings: Dictionary = {}) -> Variant:
 
 func is_valid(variant: Variant) -> bool:
 	return variant is int
+
+func is_actual_type(variant: Variant) -> bool:
+	return variant is int

--- a/addons/pandora/model/types/reference.gd
+++ b/addons/pandora/model/types/reference.gd
@@ -36,3 +36,6 @@ func write_value(variant: Variant) -> Variant:
 
 func is_valid(variant: Variant) -> bool:
 	return variant is PandoraEntity
+
+func is_actual_type(variant: Variant) -> bool:
+	return variant is PandoraEntity

--- a/addons/pandora/model/types/resource.gd
+++ b/addons/pandora/model/types/resource.gd
@@ -35,3 +35,6 @@ func is_valid(variant: Variant) -> bool:
 	# Allow String (resource paths) as they will be converted to Resources
 	# Allow Resource objects directly
 	return variant == null or variant is Resource or variant is String
+
+func is_actual_type(variant: Variant) -> bool:
+	return variant is Resource

--- a/addons/pandora/model/types/string.gd
+++ b/addons/pandora/model/types/string.gd
@@ -11,3 +11,6 @@ func _init() -> void:
 
 func is_valid(variant: Variant) -> bool:
 	return variant is String
+
+func is_actual_type(variant: Variant) -> bool:
+	return variant is String

--- a/addons/pandora/model/types/vector2.gd
+++ b/addons/pandora/model/types/vector2.gd
@@ -31,3 +31,6 @@ func write_value(variant: Variant) -> Variant:
 
 func is_valid(variant: Variant) -> bool:
 	return variant is Vector2
+
+func is_actual_type(variant: Variant) -> bool:
+	return variant is Vector2

--- a/addons/pandora/model/types/vector2i.gd
+++ b/addons/pandora/model/types/vector2i.gd
@@ -29,3 +29,6 @@ func write_value(variant: Variant) -> Variant:
 
 func is_valid(variant: Variant) -> bool:
 	return variant is Vector2i
+
+func is_actual_type(variant: Variant) -> bool:
+	return variant is Vector2i

--- a/addons/pandora/model/types/vector3.gd
+++ b/addons/pandora/model/types/vector3.gd
@@ -31,3 +31,6 @@ func write_value(variant: Variant) -> Variant:
 
 func is_valid(variant: Variant) -> bool:
 	return variant is Vector3
+
+func is_actual_type(variant: Variant) -> bool:
+	return variant is Vector3

--- a/addons/pandora/model/types/vector3i.gd
+++ b/addons/pandora/model/types/vector3i.gd
@@ -29,3 +29,6 @@ func write_value(variant: Variant) -> Variant:
 
 func is_valid(variant: Variant) -> bool:
 	return variant is Vector3i
+
+func is_actual_type(variant: Variant) -> bool:
+	return variant is Vector3i


### PR DESCRIPTION

## Description

Added a is_actual_type() to the type to differentiate type identification from the existing type conversion capability of is_valid().  When loading an Array, it's now using the is_actual_type in order to load the exact type it was saved as.  Only the array loading is using this new function, any existing uses of is_valid() have not been changed.

Loading an array of Strings identifies each element as a Color because the is_valid() of the Color type recognizes the string content before the String type is queried.  This is occuring because the is_valid() function doesn't just check for the exact type but also for any types it can convert from.  Thus, other types, like references, also exhibit the same problem.

Note, this new function will also need to be added to custom data types created by users when extending the addon data types.

## Addressed issues

Closes #210 

## Screenshots

No visible changes.
