### PR TITLE
Add data migration foundation

### DIFF
--- a/addons/pandora/api.gd
+++ b/addons/pandora/api.gd
@@ -1,12 +1,16 @@
 @tool
 extends Node
 
+const PANDORA_DATA_VERSION: int = 1
+
 const EntityIdFileGenerator = preload("res://addons/pandora/util/entity_id_file_generator.gd")
 const CategoryIdFileGenerator = preload("res://addons/pandora/util/category_id_file_generator.gd")
 const ScriptUtil = preload("res://addons/pandora/util/script_util.gd")
+const DataMigration = preload("res://addons/pandora/util/migration.gd")
 
 signal data_loaded
 signal data_loaded_failure
+signal data_migrated(ctx: StringName, old_version: int, new_version: int)
 signal entity_added(entity: PandoraEntity)
 signal import_success(imported_count: int)
 signal import_failed(reason: String)
@@ -22,6 +26,7 @@ var _entity_backend: PandoraEntityBackend
 
 var _loaded = false
 var _backend_load_state: PandoraEntityBackend.LoadState = PandoraEntityBackend.LoadState.NOT_LOADED
+var _data_version: int = -1
 
 
 func _enter_tree() -> void:
@@ -140,7 +145,21 @@ func load_data() -> void:
 		print("Skipping loading data - loaded already!")
 		data_loaded.emit()
 		return
+
 	var all_object_data = _storage.get_all_data(_context_manager.get_context_id())
+	# Older versions of Pandora don't include a version number.
+	# As a fallback, if not present, we set it to the first version,
+	# making it so we can migrate it to the latest one.
+	if all_object_data.has("_version"):
+		_data_version = all_object_data["_version"]
+	else:
+		_data_version = 0
+
+	if _data_version < PANDORA_DATA_VERSION:
+		all_object_data = DataMigration.migrate(all_object_data, _data_version, PANDORA_DATA_VERSION)
+		data_migrated.emit(_context_manager.get_context_id(), _data_version, PANDORA_DATA_VERSION)
+		_data_version = PANDORA_DATA_VERSION
+
 	if all_object_data.has("_entity_data") and not all_object_data.is_empty():
 		_backend_load_state = _entity_backend.load_data(all_object_data["_entity_data"])
 	if all_object_data.has("_id_generator") and not all_object_data.is_empty():
@@ -160,6 +179,7 @@ func save_data() -> void:
 	var all_object_data = {
 		"_entity_data": _entity_backend.save_data(),
 		"_id_generator": _id_generator.save_data(),
+		"_version": _data_version,
 	}
 	_storage.store_all_data(all_object_data, _context_manager.get_context_id())
 
@@ -248,3 +268,4 @@ func _clear() -> void:
 	_id_generator.clear()
 	_loaded = false
 	_backend_load_state = PandoraEntityBackend.LoadState.NOT_LOADED
+	_data_version = -1

--- a/addons/pandora/util/migration.gd
+++ b/addons/pandora/util/migration.gd
@@ -1,0 +1,3 @@
+
+static func migrate(data: Dictionary, old_ver: int, new_ver: int) -> Dictionary:
+    return data

--- a/addons/pandora/util/migration.gd.uid
+++ b/addons/pandora/util/migration.gd.uid
@@ -1,0 +1,1 @@
+uid://21jtq2m0x8vl

--- a/data.pandora
+++ b/data.pandora
@@ -440,5 +440,6 @@
 		"_ids_by_context": {
 			"default": 17.0
 		}
-	}
+	},
+	"_version": 1
 }

--- a/test/api_test.gd
+++ b/test/api_test.gd
@@ -172,3 +172,15 @@ func test_category_of_instance() -> void:
 	assert_that(duplicate.is_category(category.get_entity_id())).is_equal(true)
 	assert_that(instance.is_category(child_category.get_entity_id())).is_equal(true)
 	assert_that(duplicate.is_category(child_category.get_entity_id())).is_equal(true)
+
+
+func test_pandora_data_version() -> void:
+	Pandora._clear()
+	assert_that(Pandora._data_version).is_equal(-1)
+
+	Pandora.set_context_id(TEST_DIR)
+	Pandora._clear()
+	Pandora.load_data()
+	Pandora.save_data()
+
+	assert_that(Pandora._data_version).is_equal(Pandora.PANDORA_DATA_VERSION)


### PR DESCRIPTION
## Description

Introduces a versioning system for  `data.pandora`.
For now, the implementation is "mock", so the migration yields back the same dictionary and just appends the a new field to `data.pandora` for future usage: `_version`.

The idea is that, following the addressed issue vision, the Migration service will loop through a list of `.gd` files that will manipulate the data.

Files without an explicit version will be marked as version `0` before the migration starts.

## Addressed issues

- closes #238 

